### PR TITLE
Add some base 101 doc

### DIFF
--- a/content/contributing/first-time/contents.lr
+++ b/content/contributing/first-time/contents.lr
@@ -1,6 +1,6 @@
 _model: page
 ---
-sort_key: 3
+sort_key: 5
 ---
 title: First-time contributors
 ---

--- a/content/contributing/first-time/setting-up-your-environment/contents.lr
+++ b/content/contributing/first-time/setting-up-your-environment/contents.lr
@@ -6,19 +6,29 @@ _slug: setup
 ---
 body:
 
-In order to get contributing, you're going to need to setup a **development environment** - a place where you can work on code where it can behave the same as everyone else's environment. 
+In order to get contributing, you're going to need to setup a 
+**development environment** - a place where you can work on code where it can 
+behave the same as everyone else's environment. 
 
-Many parts of BeeWare use the same tools: a specific version of Python, and virtual environment controls. 
+Many parts of BeeWare use the same tools: a specific version of Python, and 
+virtual environment controls. 
 
 Python
 -----------
 
-Python is a scripting language, which is available on a number of different operating systems. 
-However, depending on what system you are using, your version of Python is going 
+Python is a scripting language, which is available on a number of different 
+operating systems. However, depending on what system you are using, your 
+version of Python is going 
 to be different. Because of this reason, we specify exactly what version of Python
 we expect the code to work with. 
 
-For the following instructions, we're going to assume that you know exactly which version of Python you need to install. Normally this is listed in the README.md file or in the tutorial information. Our `CI </contributing/first-time/what-is/ci>`_ systems have to be told exactly what version of Python is required, too. So if you're really stuck, try looking at the :code:`.travis.yml` or :code:`circle.yml` file for the specific version you need. 
+For the following instructions, we're going to assume that you know exactly
+which version of Python you need to install. Normally this is listed in the
+README.md file or in the tutorial information. Our `CI
+</contributing/first-time/what-is/ci>`_ systems have to be told exactly what
+version of Python is required, too. So if you're really stuck, try looking at
+the :code:`.travis.yml` or :code:`circle.yml` file for the specific version you
+need. 
 
 pyenv
 ~~~~~~
@@ -30,7 +40,10 @@ version you need for a particular project.
  * MacOSX - You can install pyenv via `brew </contributing/first-time/what-is/package-managers>`_,  by running :code:`brew install pyenv`
  * Other - use the `automatic installer <https://github.com/yyuu/pyenv-installer>`_. 
 
-Once :code:`pyenv` is installed, you need to install the specific Python version. This information is stored in a  :code:`.python-version` file, which means you can have different versions of Python used in different projects on your computer. 
+Once :code:`pyenv` is installed, you need to install the specific Python
+version. This information is stored in a  :code:`.python-version` file, which
+means you can have different versions of Python used in different projects on
+your computer. 
 
 To install and set Python version: 
 
@@ -45,7 +58,10 @@ More information about pyenv is available on `their website <https://github.com/
 virtualenv
 -----------
 
-Once Python is installed, you're going to want to be able to install different Python packages. Since you may have more than one project being worked on, and more than one version of Python, having a way to make sure that only specific Python packages are available at any one time is handy. 
+Once Python is installed, you're going to want to be able to install different
+Python packages. Since you may have more than one project being worked on, and
+more than one version of Python, having a way to make sure that only specific
+Python packages are available at any one time is handy. 
 
 One way we can do this is via `virtualenv <https://virtualenv.pypa.io/en/stable/>`_. 
 
@@ -55,7 +71,10 @@ Using `pip </contributing/first-time/what-is/package-managers>`_, we can install
   
   $ pip install virtualenv
 
-Then, we want to setup a virtualenv that we can then activate. Having more than one virtualenv is ok, but only one can be activated at a time. Make sure you have your Python selection done with :code:`pyenv`, so that we know what version of Python to use
+Then, we want to setup a virtualenv that we can then activate. Having more than
+one virtualenv is ok, but only one can be activated at a time. Make sure you
+have your Python selection done with :code:`pyenv`, so that we know what
+version of Python to use
 
 
 .. code-block:: bash
@@ -69,7 +88,8 @@ Then, we can activate the virtual environment.
   
  $ . env/bin/activate
 
-This will result in a little note in your command line letting you know you're in a virtual environment
+This will result in a little note in your command line letting you know you're
+in a virtual environment
 
 .. code-block:: bash
   

--- a/content/contributing/first-time/setting-up-your-environment/contents.lr
+++ b/content/contributing/first-time/setting-up-your-environment/contents.lr
@@ -1,0 +1,88 @@
+_model: page
+---
+title: Setting up your environment
+---
+_slug: setup
+---
+body:
+
+In order to get contributing, you're going to need to setup a **development environment** - a place where you can work on code where it can behave the same as everyone else's environment. 
+
+Many parts of BeeWare use the same tools: a specific version of Python, and virtual environment controls. 
+
+Python
+-----------
+
+Python is a scripting language, which is available on a number of different operating systems. 
+However, depending on what system you are using, your version of Python is going 
+to be different. Because of this reason, we specify exactly what version of Python
+we expect the code to work with. 
+
+For the following instructions, we're going to assume that you know exactly which version of Python you need to install. Normally this is listed in the README.md file or in the tutorial information. Our `CI </contributing/first-time/what-is/ci>`_ systems have to be told exactly what version of Python is required, too. So if you're really stuck, try looking at the :code:`.travis.yml` or :code:`circle.yml` file for the specific version you need. 
+
+pyenv
+~~~~~~
+
+`pyenv <https://github.com/yyuu/pyenv>`_ is a way to get multiple versions of 
+Python working on your machine at the same time. It allows you to pick and choose whichever
+version you need for a particular project. 
+
+ * MacOSX - You can install pyenv via `brew </contributing/first-time/what-is/package-managers>`_,  by running :code:`brew install pyenv`
+ * Other - use the `automatic installer <https://github.com/yyuu/pyenv-installer>`_. 
+
+Once :code:`pyenv` is installed, you need to install the specific Python version. This information is stored in a  :code:`.python-version` file, which means you can have different versions of Python used in different projects on your computer. 
+
+To install and set Python version: 
+
+.. code-block:: bash
+
+    $ cd /path/to/your/project
+    $ pyenv install 3.5.1
+    $ pyenv local 3.5.1
+
+More information about pyenv is available on `their website <https://github.com/yyuu/pyenv/blob/master/COMMANDS.md>`_
+
+virtualenv
+-----------
+
+Once Python is installed, you're going to want to be able to install different Python packages. Since you may have more than one project being worked on, and more than one version of Python, having a way to make sure that only specific Python packages are available at any one time is handy. 
+
+One way we can do this is via `virtualenv <https://virtualenv.pypa.io/en/stable/>`_. 
+
+Using `pip </contributing/first-time/what-is/package-managers>`_, we can install virtualenv
+
+.. code-block:: bash
+  
+  $ pip install virtualenv
+
+Then, we want to setup a virtualenv that we can then activate. Having more than one virtualenv is ok, but only one can be activated at a time. Make sure you have your Python selection done with :code:`pyenv`, so that we know what version of Python to use
+
+
+.. code-block:: bash
+  
+  $ virtualenv -p $(which python3) env
+
+Then, we can activate the virtual environment. 
+
+
+.. code-block:: bash
+  
+ $ . env/bin/activate
+
+This will result in a little note in your command line letting you know you're in a virtual environment
+
+.. code-block:: bash
+  
+ (env) $
+
+To disable your virtualenv: 
+
+.. code-block:: bash
+  
+ $ deactivate
+
+
+---
+summary: How to get your system setup to contribute
+---
+sort_key: 4

--- a/content/contributing/first-time/what-is-a/ci/contents.lr
+++ b/content/contributing/first-time/what-is-a/ci/contents.lr
@@ -1,0 +1,18 @@
+_model: page
+---
+title: CI
+---
+body:
+
+Continuous integration, or CI, is a way that we can test code continuously. These systems will automatically listen for new Pull Requests and other events, and automatically run test suites, and other automatic processes. 
+
+We use a number of different CI systems: `Travis CI <https://travis-ci.com/>`_ and `Circle CI <https://circleci.com/>`_. Normally the *build status* of a project is displayed as a image on a project's README file. Green means the tests have been successful, and red means they have not. Clicking the image will show you the results of these tests. 
+---
+gutter:
+
+Unsure which CI environment is being used?
+--------------------------------------------------------
+
+Check for the configuration file. `.travis.yml` is Travis, `circle.yml` is Circle CI. 
+---
+summary: What is CI, or Continuous Integration

--- a/content/contributing/first-time/what-is-a/ci/contents.lr
+++ b/content/contributing/first-time/what-is-a/ci/contents.lr
@@ -4,9 +4,15 @@ title: CI
 ---
 body:
 
-Continuous integration, or CI, is a way that we can test code continuously. These systems will automatically listen for new Pull Requests and other events, and automatically run test suites, and other automatic processes. 
+Continuous integration, or CI, is a way that we can test code continuously.
+These systems will automatically listen for new Pull Requests and other events,
+and automatically run test suites, and other automatic processes. 
 
-We use a number of different CI systems: `Travis CI <https://travis-ci.com/>`_ and `Circle CI <https://circleci.com/>`_. Normally the *build status* of a project is displayed as a image on a project's README file. Green means the tests have been successful, and red means they have not. Clicking the image will show you the results of these tests. 
+We use a number of different CI systems: `Travis CI <https://travis-ci.com/>`_
+and `Circle CI <https://circleci.com/>`_. Normally the *build status* of a
+project is displayed as a image on a project's README file. Green means the
+tests have been successful, and red means they have not. Clicking the image
+will show you the results of these tests. 
 ---
 gutter:
 

--- a/content/contributing/first-time/what-is-a/contents.lr
+++ b/content/contributing/first-time/what-is-a/contents.lr
@@ -1,0 +1,9 @@
+_model: page
+---
+title: What is...?
+---
+_slug: 
+---
+summary: Confused about what something is? We've described a number of things here
+---
+sort_key: 5

--- a/content/contributing/first-time/what-is-a/git/contents.lr
+++ b/content/contributing/first-time/what-is-a/git/contents.lr
@@ -1,0 +1,15 @@
+_model: page
+---
+title: git
+---
+body:
+
+:code:`git` is a `Version Control System <https://en.wikipedia.org/wiki/Version_control>`_, which lets us save, store and share changes to code over time.
+
+ `GitHub <https://github.com>`_ is just :code:`git` under the hood, but includes a lot of helpful things, like a web interface, and nice Pull Requests and Issue Tracking systems. 
+
+
+---
+gutter: 
+---
+summary: What is git anyway?

--- a/content/contributing/first-time/what-is-a/git/contents.lr
+++ b/content/contributing/first-time/what-is-a/git/contents.lr
@@ -4,9 +4,13 @@ title: git
 ---
 body:
 
-:code:`git` is a `Version Control System <https://en.wikipedia.org/wiki/Version_control>`_, which lets us save, store and share changes to code over time.
+:code:`git` is a `Version Control System
+<https://en.wikipedia.org/wiki/Version_control>`_, which lets us save, store
+and share changes to code over time.
 
- `GitHub <https://github.com>`_ is just :code:`git` under the hood, but includes a lot of helpful things, like a web interface, and nice Pull Requests and Issue Tracking systems. 
+ `GitHub <https://github.com>`_ is just :code:`git` under the hood, but
+includes a lot of helpful things, like a web interface, and nice Pull Requests
+and Issue Tracking systems. 
 
 
 ---

--- a/content/contributing/first-time/what-is-a/package-manager/contents.lr
+++ b/content/contributing/first-time/what-is-a/package-manager/contents.lr
@@ -1,0 +1,33 @@
+_model: page
+---
+title: Package Managers
+---
+body:
+
+Installing software on your computer can be interesting. Sometimes you have to download a file and then install it yourself, or copy files to specific places on your computer. 
+
+However, `package managers` help make this process easier by allowing for the automation of installation of software. 
+
+There are different levels of package managers: for the operating system level, as well as one specifically for Python packages. 
+
+
+MacOSX
+---------------
+
+`Homebrew <http://brew.sh/>`_ is the standard for installing software on your Mac. This is the system that's used if you run a :code:`brew install` command. 
+
+Linux
+------------
+
+Depending on what family of operating system you run, you'll use :code:`apt-get` (for Debian and Ubuntu) or :code:`yum` (for Red Hat and Centos)
+
+Python
+------------
+
+:code:`pip` is the way you can install Python software. Running :code:`pip install` uses the `Python Packaging Index <https://pypi.python.org/pypi>`_, also known as `PyPI` or "The Cheese Shop", it's a central repository for Python code. Many BeeWare projects can be installed using `pip`. 
+
+Why is it called "The Cheese Shop"? It's a `Monty Python <https://www.youtube.com/watch?v=cWDdd5KKhts>`_ reference :)
+---
+gutter: 
+---
+summary: How you can manage your installed packages

--- a/content/contributing/first-time/what-is-a/package-manager/contents.lr
+++ b/content/contributing/first-time/what-is-a/package-manager/contents.lr
@@ -4,29 +4,39 @@ title: Package Managers
 ---
 body:
 
-Installing software on your computer can be interesting. Sometimes you have to download a file and then install it yourself, or copy files to specific places on your computer. 
+Installing software on your computer can be interesting. Sometimes you have to
+download a file and then install it yourself, or copy files to specific places
+on your computer. 
 
-However, `package managers` help make this process easier by allowing for the automation of installation of software. 
+However, `package managers` help make this process easier by allowing for the
+automation of installation of software. 
 
-There are different levels of package managers: for the operating system level, as well as one specifically for Python packages. 
+There are different levels of package managers: for the operating system level,
+as well as one specifically for Python packages. 
 
 
 MacOSX
 ---------------
 
-`Homebrew <http://brew.sh/>`_ is the standard for installing software on your Mac. This is the system that's used if you run a :code:`brew install` command. 
+`Homebrew <http://brew.sh/>`_ is the standard for installing software on your
+Mac. This is the system that's used if you run a :code:`brew install` command. 
 
 Linux
 ------------
 
-Depending on what family of operating system you run, you'll use :code:`apt-get` (for Debian and Ubuntu) or :code:`yum` (for Red Hat and Centos)
+Depending on what family of operating system you run, you'll use
+:code:`apt-get` (for Debian and Ubuntu) or :code:`yum` (for Red Hat and Centos)
 
 Python
 ------------
 
-:code:`pip` is the way you can install Python software. Running :code:`pip install` uses the `Python Packaging Index <https://pypi.python.org/pypi>`_, also known as `PyPI` or "The Cheese Shop", it's a central repository for Python code. Many BeeWare projects can be installed using `pip`. 
+:code:`pip` is the way you can install Python software. Running :code:`pip
+install` uses the `Python Packaging Index <https://pypi.python.org/pypi>`_,
+also known as `PyPI` or "The Cheese Shop", it's a central repository for Python
+code. Many BeeWare projects can be installed using `pip`. 
 
-Why is it called "The Cheese Shop"? It's a `Monty Python <https://www.youtube.com/watch?v=cWDdd5KKhts>`_ reference :)
+Why is it called "The Cheese Shop"? It's a `Monty Python
+<https://www.youtube.com/watch?v=cWDdd5KKhts>`_ reference :)
 ---
 gutter: 
 ---


### PR DESCRIPTION
Based on [some comments](https://twitter.com/freakboy3742/status/786017538584956928) earlier today, I thought it would be a good idea to stub out some of the 'bare bones' how-to doc that we can link to across projects, especially in tutorials. 

For now this may be duplicating content, but I want to make sure these docs are linked in places where we say things like "We assume you already have...", such as in the Batavia tutorials. 

ping @freakboy3742 for BFDN blessing