### PR TITLE
Add a sitemap

### DIFF
--- a/BeeWare.lektorproject
+++ b/BeeWare.lektorproject
@@ -1,5 +1,6 @@
 [project]
 name = BeeWare
+url = http://pybee.org
 
 [alternatives.en]
 name = English

--- a/content/404.html/contents.lr
+++ b/content/404.html/contents.lr
@@ -1,3 +1,5 @@
 _model: none
 ---
 _template: 404.html
+---
+_discoverable: no

--- a/content/b/contents.lr
+++ b/content/b/contents.lr
@@ -4,6 +4,6 @@ title: Shortlinks
 ---
 hide_from_index: no
 ---
-_discoverable: yes
+_discoverable: no
 ---
 _hidden: no

--- a/content/batavia/contents.lr
+++ b/content/batavia/contents.lr
@@ -3,3 +3,5 @@ _model: redirect
 old_path: /batavia/
 ---
 new_path: /project/projects/bridges/batavia/
+---
+_discoverable: no

--- a/content/bee/contents.lr
+++ b/content/bee/contents.lr
@@ -4,6 +4,6 @@ title: Shortlinks
 ---
 hide_from_index: no
 ---
-_discoverable: yes
+_discoverable: no
 ---
 _hidden: no

--- a/content/briefcase/contents.lr
+++ b/content/briefcase/contents.lr
@@ -3,3 +3,5 @@ _model: redirect
 old_path: /briefcase/
 ---
 new_path: /project/projects/tools/briefcase/
+---
+_discoverable: no

--- a/content/bugjar/contents.lr
+++ b/content/bugjar/contents.lr
@@ -3,3 +3,5 @@ _model: redirect
 old_path: /bugjar/
 ---
 new_path: /project/projects/tools/bugjar/
+---
+_discoverable: no

--- a/content/cassowary/contents.lr
+++ b/content/cassowary/contents.lr
@@ -3,3 +3,5 @@ _model: redirect
 old_path: /cassowary/
 ---
 new_path: /project/projects/attic/cassowary/
+---
+_discoverable: no

--- a/content/colosseum/contents.lr
+++ b/content/colosseum/contents.lr
@@ -3,3 +3,5 @@ _model: redirect
 old_path: /colosseum/
 ---
 new_path: /project/projects/libraries/colosseum/
+---
+_discoverable: no

--- a/content/cricket/contents.lr
+++ b/content/cricket/contents.lr
@@ -3,3 +3,5 @@ _model: redirect
 old_path: /cricket/
 ---
 new_path: /project/projects/tools/cricket/
+---
+_discoverable: no

--- a/content/duvet/contents.lr
+++ b/content/duvet/contents.lr
@@ -3,3 +3,5 @@ _model: redirect
 old_path: /duvet/
 ---
 new_path: /project/projects/tools/duvet/
+---
+_discoverable: no

--- a/content/galley/contents.lr
+++ b/content/galley/contents.lr
@@ -3,3 +3,5 @@ _model: redirect
 old_path: /galley/
 ---
 new_path: /project/projects/tools/galley/
+---
+_discoverable: no

--- a/content/rubicon/contents.lr
+++ b/content/rubicon/contents.lr
@@ -3,3 +3,5 @@ _model: redirect
 old_path: /rubicon/
 ---
 new_path: /project/projects/bridges/rubicon/
+---
+_discoverable: no

--- a/content/signup/contents.lr
+++ b/content/signup/contents.lr
@@ -3,3 +3,5 @@ _model: redirect
 old_path: /signup/
 ---
 new_path: /community/keep-informed/
+---
+_discoverable: no

--- a/content/sitemap.xml/contents.lr
+++ b/content/sitemap.xml/contents.lr
@@ -1,0 +1,5 @@
+_template: sitemap.xml
+---
+_model: none
+---
+_discoverable:no

--- a/content/sitemap/contents.lr
+++ b/content/sitemap/contents.lr
@@ -1,0 +1,7 @@
+_template: sitemap.html
+---
+summary: Need to find a page? Here's a programatically generated list of all the pages, including how they are nested together!
+---
+title: Sitemap
+---
+_discoverable: no

--- a/content/toga/contents.lr
+++ b/content/toga/contents.lr
@@ -3,3 +3,5 @@ _model: redirect
 old_path: /toga/
 ---
 new_path: /project/projects/libraries/toga/
+---
+_discoverable: no

--- a/content/voc/contents.lr
+++ b/content/voc/contents.lr
@@ -3,3 +3,5 @@ _model: redirect
 old_path: /voc/
 ---
 new_path: /project/projects/bridges/voc/
+---
+_discoverable: no

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -82,7 +82,9 @@ ga('send', 'pageview');
         <p class="pull-xs-right pull-sm-right pull-md-right pull-lg-right pull-xl-right">&copy; Russell Keith-Magee 2016</p>
         <p><a href="https://github.com/pybee/"><i class="fa fa-github fa-lg" aria-hidden="true"></i> GitHub</a> |
         <a href="https://gitter.im/pybee/general/">Gitter</a> |
-        <a href="https://twitter.com/PyBeeWare/"><i class="fa fa-twitter fa-lg" aria-hidden="true"></i> Twitter</a></p>
+        <a href="https://twitter.com/PyBeeWare/"><i class="fa fa-twitter fa-lg" aria-hidden="true"></i> Twitter</a> | 
+        <a href="/sitemap">Sitemap</a>
+</p>
       </div>
     </footer>
 

--- a/templates/sitemap.html
+++ b/templates/sitemap.html
@@ -1,0 +1,13 @@
+{% extends "page.html" %}
+{% block title %}Sitemap{% endblock %}
+{% block body %}
+<ul class="sitemap">
+  {% for page in [site.root] recursive %}
+  <li><a href="{{ page|url }}">{{ page.record_label }}</a>
+    {% if page.children %}
+      <ul>{{ loop(page.children) }}</ul>
+    {% endif %}
+  </li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/templates/sitemap.xml
+++ b/templates/sitemap.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  {%- for page in [site.root] if page != this recursive %}
+  <url><loc>{{ page|url(external=true) }}</loc></url>
+  {{- loop(page.children) }}
+  {%- endfor %}
+</urlset>


### PR DESCRIPTION
Linked from the footer, a sitemap of all the pages in the website

I find these helpful for when I want to get a full list of all the pages on the site

It does expose where we're using nodes as page content, not as separate pages, but I think that's a good thing for discoverability. 

I've also enabled `_discoverable: no` for a bunch of the redirects we have. 