### PR TITLE
translate the "core team..." page to pt_BR

### DIFF
--- a/content/contributing/core-team/contents+pt.lr
+++ b/content/contributing/core-team/contents+pt.lr
@@ -1,6 +1,6 @@
 body:
 
-Aquelas abelhas ocupadas do `Time Central </community/team>`_ tem
+Aquelas abelhas ocupadas do `Time Principal </community/team>`_ tem
 algumas responsabilidades para manter a colmeia que é o BeeWare se 
 movendo. Esse é um projeto em evolução, portanto esta página deve mudar.
 
@@ -32,16 +32,16 @@ Apicultor:
 Apicultor Sênior:
  - Apicultores com elevado acesso no GitHub, e também com um nível de responsabilidade 
    para supervisionar o projeto como um todo. Eles podem fazer decisões sobre a 
-   arquitetura, mas precisão responder ao DBDV.
+   arquitetura, mas precisão responder ao BDFN.
 
 Apicultor Fundador: `Russell Keith-Magee <https://twitter.com/freakboy3742>`_
  - O primeiro homem que subiu na colina e viu um iaque(yak) que precisava ser tosquiado 
  - Esse papel nunca muda e continua ad infinitum 
- - Esse papel é diferente do DBDV. 
+ - Esse papel é diferente do BDFN. 
 
-Ditador Benevolente da Vez (DBDV): `Russell Keith-Magee <https://twitter.com/freakboy3742>`_
- - Assim como o `Ditador Benevolente Vitalício <https://en.wikipedia.org/wiki/Benevolent_dictator_for_life>`_, a responsabilidade fica com o DBDV. 
-   O uso de "Da Vez" é o oposto de "Vitalício" como referência ao lema do Django de não atribuir 
+Bee-nevolent Dictator for Now (BDFN): `Russell Keith-Magee <https://twitter.com/freakboy3742>`_
+ - Assim como o `Benevolent Dictator for Life <https://en.wikipedia.org/wiki/Benevolent_dictator_for_life>`_, a responsabilidade fica com o BDFN. 
+   O uso de "for Now" é o oposto de "for Life" como referência ao lema do Django de não atribuir 
    a responsabilidade de principal mantenedor para toda a vida de uma pessoa. Existe vida para 
    além do open source e o equilíbrio entre programar/viver e bem-estar é algo importante para 
    se ter em mente.
@@ -54,7 +54,7 @@ Como qualquer projeto com mais de uma pessoa com direito de fazer commit,
 existem algumas orientações que o time deve seguir:
 
 
-* **Ser um bom representante do projeto para a comunidade como um todo.**
+ * **Ser um bom representante do projeto para a comunidade como um todo.**
 
  * **Tratar todas as perguntas e contribuições para qualquer projeto do BeeWare com respeito.**
 
@@ -69,16 +69,16 @@ existem algumas orientações que o time deve seguir:
  * **Encorajar outros membros da comunidade a refletir esses ideais em suas próprias comunicações,
    tanto dentro quanto fora da comunidade BeeWare.**
 
- *  Nenhum Apicultor deve commitar seu próprio código
+ *  Nenhum Apicultor deve fazer um commit de seu próprio código
      - Exceção: "Alguma coisa está quebrada e precisa ser consertada agora".
-     - Exceção: DBDV (isso pode mudar no futuro).
+     - Exceção: BDFN (isso pode mudar no futuro).
 
- * Todo código submetido a revisão por um membro do time central deve ser revisto por outro membro do time.
-     - Exceção: DBDV (isso pode mudar no futuro).
+ * Todo código submetido a revisão por um membro do time principal deve ser revisto por outro membro do time.
+     - Exceção: BDFN (isso pode mudar no futuro).
 
  * Todo o código deve passar por testes de Integração Contínua antes de ser incorporado.
      - Exceção: código que sabemos estar quebrado e precisa ser feito o commit por outros motivos.
-     - Exceção: código em um repositório com numero de teste de IC insuficientes.
+     - Exceção: código em um repositório com numero de teste de CI insuficientes.
      - Exceção: Funcionando e commitado é melhor do que perfeito e não.
 
   * Processo de aceitação deve ser automatizado sempre que possível.
@@ -92,7 +92,7 @@ Tornando-se um Apicultor
 ---------------------------------
 
 A inclusão de um novo apicultor no time é de inteira responsabilidade do
-Time Central existente. Embora ainda não exista regras claras sobre isso, no 
+Time Principal existente. Embora ainda não exista regras claras sobre isso, no 
 geral, alguém será convidado a ser um Apicultor no projeto BeeWare se ele 
 tiver demonstrado solidas contribuições ao projeto. Isso pode ser estendido
 para alguém com um conhecimento específico em um domínio (por exemplo, 
@@ -102,8 +102,8 @@ pedir a permissão de poder fazer commits no projeto.
 
 Todos os novos apicultores serão 'introduzidos' (por falta de uma palavra melhor) 
 nos valores e orientações centrais do projeto. Um resumo dos valores centrais pode 
-ser encontrado `na página Sobre <http://pybee.org/project/about/>`_. Espera-se que 
-qualquer um que entre no time detenha esses valores e contribua para o debate e 
+ser encontrado `na página Sobre o projeto <http://pybee.org/project/about/>`_. Espera-se 
+que qualquer um que entre no time detenha esses valores e contribua para o debate e 
 evolução desses dos mesmos no decorrer do tempo.
 
 Qualquer Apicultor, novo ou velho, não tem a obrigação de manter nenhuma parte 
@@ -127,6 +127,6 @@ diretamente  no projeto.
 ---
 sort_key: 4
 ---
-summary: O que é o time central e o que eles fazem?
+summary: O que é o time principal e o que ele faz?
 ---
-title: Time Central e suas Responsabilidades
+title: O Time Principal e suas Responsabilidades

--- a/content/contributing/core-team/contents+pt.lr
+++ b/content/contributing/core-team/contents+pt.lr
@@ -1,0 +1,132 @@
+body:
+
+Aquelas abelhas ocupadas do `Time Central </community/team>`_ tem
+algumas responsabilidades para manter a colmeia que é o BeeWare se 
+movendo. Esse é um projeto em evolução, portanto esta página deve mudar.
+
+Isso inclui, mas não se limita apenas a responder aos problemas, revisar e
+aceitar código, mentorar novos contribuidores e arquitetar o projeto BeeWare
+como um todo.
+
+Existem pessoas que nós confiamos para fazer decisões de código, pessoas que
+confiamos para decidir a organização do código e tem uma pessoa com quem a
+responsabilidade metaforicamente fica, que guia a visão de toda a organização 
+e muitas vezes é seu maior torcedor.
+
+Esses níveis podem ser descritos como:
+
+Abelha ou Abelha Operária:
+ - Qualquer membro da comunidade BeeWare. Dado que nós trabalhamos abertamente 
+   no GitHub, qualquer pessoas pode sugerir mudanças no código e ter seu código aceito. 
+   O único limite para sua capacidade de contribuir é ter seu trabalho incluído por um 
+   membro do time que tenha as permissões de faze-lo. 
+
+Apicultor:
+ - Uma abelha que foi reconhecida como um contribuidor confiável. Essas abelhas 
+   tem demonstrado habilidade em relação a alguma parte especifica do projeto 
+   BeeWare por um período de tempo. Pode ser em um nível técnico (competência em 
+   JavaScript, Python, Objective-C; GTK+, conhecimento em macOS) ou em outro nível 
+   (administração da comunidade, revisão de código). Apicultores podem ter também 
+   o direito fazer commit bits para o projeto onde sua especialidade é reconhecida.
+
+Apicultor Sênior:
+ - Apicultores com elevado acesso no GitHub, e também com um nível de responsabilidade 
+   para supervisionar o projeto como um todo. Eles podem fazer decisões sobre a 
+   arquitetura, mas precisão responder ao DBDV.
+
+Apicultor Fundador: `Russell Keith-Magee <https://twitter.com/freakboy3742>`_
+ - O primeiro homem que subiu na colina e viu um iaque(yak) que precisava ser tosquiado 
+ - Esse papel nunca muda e continua ad infinitum 
+ - Esse papel é diferente do DBDV. 
+
+Ditador Benevolente da Vez (DBDV): `Russell Keith-Magee <https://twitter.com/freakboy3742>`_
+ - Assim como o `Ditador Benevolente Vitalício <https://en.wikipedia.org/wiki/Benevolent_dictator_for_life>`_, a responsabilidade fica com o DBDV. 
+   O uso de "Da Vez" é o oposto de "Vitalício" como referência ao lema do Django de não atribuir 
+   a responsabilidade de principal mantenedor para toda a vida de uma pessoa. Existe vida para 
+   além do open source e o equilíbrio entre programar/viver e bem-estar é algo importante para 
+   se ter em mente.
+
+
+Orientações (não necessariamente regras)
+-----------------------------------------------------
+
+Como qualquer projeto com mais de uma pessoa com direito de fazer commit, 
+existem algumas orientações que o time deve seguir:
+
+
+* **Ser um bom representante do projeto para a comunidade como um todo.**
+
+ * **Tratar todas as perguntas e contribuições para qualquer projeto do BeeWare com respeito.**
+
+ * **Presumir que todos tem boas intenções, mesmo se eles não tiverem escolhido bem suas palavras.**
+
+ * **Presumir que se alguém fizer algo da forma "errada", é porque nós falhamos no processo de 
+   comunicação.**
+ 
+ * **Presumir que qualquer manifestação de raiva ou frustração vem de um genuíno desejo de usar 
+   uma ferramenta/biblioteca da BeeWare.**
+
+ * **Encorajar outros membros da comunidade a refletir esses ideais em suas próprias comunicações,
+   tanto dentro quanto fora da comunidade BeeWare.**
+
+ *  Nenhum Apicultor deve commitar seu próprio código
+     - Exceção: "Alguma coisa está quebrada e precisa ser consertada agora".
+     - Exceção: DBDV (isso pode mudar no futuro).
+
+ * Todo código submetido a revisão por um membro do time central deve ser revisto por outro membro do time.
+     - Exceção: DBDV (isso pode mudar no futuro).
+
+ * Todo o código deve passar por testes de Integração Contínua antes de ser incorporado.
+     - Exceção: código que sabemos estar quebrado e precisa ser feito o commit por outros motivos.
+     - Exceção: código em um repositório com numero de teste de IC insuficientes.
+     - Exceção: Funcionando e commitado é melhor do que perfeito e não.
+
+  * Processo de aceitação deve ser automatizado sempre que possível.
+     - Isso significa testes, verificações de sintaxe, de ortografia, cobertura de funcionalidades e mais.
+     - Esse é um `trabalho em desenvolvimento <http://pybee.org/project/projects/tools/beefore/>`_
+
+
+
+
+Tornando-se um Apicultor
+---------------------------------
+
+A inclusão de um novo apicultor no time é de inteira responsabilidade do
+Time Central existente. Embora ainda não exista regras claras sobre isso, no 
+geral, alguém será convidado a ser um Apicultor no projeto BeeWare se ele 
+tiver demonstrado solidas contribuições ao projeto. Isso pode ser estendido
+para alguém com um conhecimento específico em um domínio (por exemplo, 
+iOS/macOS) que pode estar faltando no time atual. Isso não precisa ser baseado
+em commits. Qualquer um que demonstrar interesse no projeto no geral pode 
+pedir a permissão de poder fazer commits no projeto.
+
+Todos os novos apicultores serão 'introduzidos' (por falta de uma palavra melhor) 
+nos valores e orientações centrais do projeto. Um resumo dos valores centrais pode 
+ser encontrado `na página Sobre <http://pybee.org/project/about/>`_. Espera-se que 
+qualquer um que entre no time detenha esses valores e contribua para o debate e 
+evolução desses dos mesmos no decorrer do tempo.
+
+Qualquer Apicultor, novo ou velho, não tem a obrigação de manter nenhuma parte 
+sozinho. Existem muitos apicultores e muitos outros além desses que podem oferecer
+ajuda, conselhos e mentorias.
+
+---
+gutter:
+
+"Commit bit"?
+--------------------------------
+
+Nos sistemas Unix, um único bit em um arquivo é usado para demonstrar 
+permissão de executar um arquivo. Em sistemas de controle de versão, um 
+bit similar existe para demonstrar a capacidade de incorporar um código. 
+Dizer que alguém tem um "commit bit" significa que ele tem o direito de 
+escrever em uma base de código. Em termos de GitHub, isso significa que 
+eles tem o direito de incorporar Pull Requests e commits de código 
+diretamente  no projeto.
+
+---
+sort_key: 4
+---
+summary: O que é o time central e o que eles fazem?
+---
+title: Time Central e suas Responsabilidades

--- a/content/contributing/first-time/more/contents+pt.lr
+++ b/content/contributing/first-time/more/contents+pt.lr
@@ -2,8 +2,8 @@ body:
 
 Esses recursos vem de fora da BeeWare, mas estão repletos de informação. (em Inglês)
 
- * `Como Contribuir com Open Source - FreeCodeCamp <https://github.com/FreeCodeCamp/how-to-contribute-to-open-source>`_
- * `Como Contribuir para um Projeto Open Source no GitHub - EggHead.io <https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github>`_
+ * `How to Contribute to Open Source - FreeCodeCamp <https://github.com/FreeCodeCamp/how-to-contribute-to-open-source>`_ (Como Contribuir com um projeto Open Source)
+ * `How to Contribute to an Open Source Project on GitHub - EggHead.io <https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github>`_ (Como Contribuir para um Projeto Open Source no GitHub)
 
 -----
 

--- a/content/contributing/first-time/setting-up-your-environment/contents+pt.lr
+++ b/content/contributing/first-time/setting-up-your-environment/contents+pt.lr
@@ -19,7 +19,7 @@ qual versão do Python esperamos que o código funcione.
 
 Para as próximas instruções, nós vamos presumir que você sabe exatamente
 qual versão do Python você precisa instalar. Normalmente isso está listado no
-arquivo README.md ou no tutorial de informação. Nosso sistema `IC 
+arquivo README.md ou no tutorial de informação. Nosso sistema `CI 
 </contributing/first-time/what-is-a/ci>`_ deve falar exatamente qual versão
 do Python é necessária também. Então se você estiver perdido, tente procurar
 no arquivo :code:`.travis.yml` ou :code:`circle.yml` para a versão específica que

--- a/content/contributing/first-time/what-is-a/ci/contents+pt.lr
+++ b/content/contributing/first-time/what-is-a/ci/contents+pt.lr
@@ -1,11 +1,11 @@
 body:
 
-Integração continua ou IC, é uma forma de testar o código constantemente.
+Integração continua ou CI, é uma forma de testar o código constantemente.
 Esses sistemas vão procurar por novas Pull Requests e outros eventos, 
 e automaticamente rodar suítes de testes e outros processos automáticos. 
  
-Nós usamos uma quantidade de diferentes sistemas de IC: 
-`Travis IC <https://travis-ci.com/>`_ e `Circle CI <https://circleci.com/>`_.
+Nós usamos uma quantidade de diferentes sistemas de CI: 
+`Travis CI <https://travis-ci.com/>`_ e `Circle CI <https://circleci.com/>`_.
 Normalmente o *status da build* de um projeto é mostrado como uma imagem
 do arquivo README do projeto. Verde significa que o teste foi um sucesso, e 
 vermelho significa que não foi. Clicar na imagem vai mostrar o resultado desses
@@ -14,13 +14,13 @@ testes para você.
 ---
 gutter:
 
-Não sabe qual ambiente de IC está sendo usado ?
+Não sabe qual ambiente de CI está sendo usado ?
 -----------------------------------------------------------
 
-Procure nos arquivo de configuração `travis.yml` é o Travis e `circle.yml` é IC circular.
+Procure nos arquivo de configuração `travis.yml` é o Travis e `circle.yml` é o Circle CI.
 
 
 ---
-summary: O que é IC ou Integração Continua
+summary: O que é CI ou Continuous Integration (Integração Continua)
 ---
-title: IC
+title: CI

--- a/content/contributing/first-time/what-is-a/git/contents+pt.lr
+++ b/content/contributing/first-time/what-is-a/git/contents+pt.lr
@@ -5,8 +5,7 @@ body:
 e compartilhar modificações no código no decorrer do tempo.
 and share changes to code over time.
 
- `GitHub <https://github.com>`_ é apenas :code:`git` por baixo dos panos, 
-
+`GitHub <https://github.com>`_ é apenas :code:`git` por baixo dos panos, 
 mas inclui um monte de coisas, como uma interface web e um bom sistema de 
 Pull Request e Rastreamento de Erros.
 

--- a/content/contributing/first-time/what-is-a/git/contents.lr
+++ b/content/contributing/first-time/what-is-a/git/contents.lr
@@ -4,14 +4,13 @@ title: git
 ---
 body:
 
-:code:`git` is a `Version Control System
+:code:`git` is a `Version Control System 
 <https://en.wikipedia.org/wiki/Version_control>`_, which lets us save, store
 and share changes to code over time.
 
- `GitHub <https://github.com>`_ is just :code:`git` under the hood, but
-includes a lot of helpful things, like a web interface, and nice Pull Requests
-and Issue Tracking systems. 
-
+`GitHub <https://github.com>`_ is just :code:`git` under the hood, but includes 
+a lot of helpful things, like a web interface, and nice Pull Requests and Issue 
+Tracking systems. 
 
 ---
 gutter: 

--- a/content/contributing/first-time/what-is-a/package-manager/contents+pt.lr
+++ b/content/contributing/first-time/what-is-a/package-manager/contents+pt.lr
@@ -28,10 +28,10 @@ Python
 
 :code:`pip` é a forma como você instala software Python. Rodando :code:`pip install`
 usa o `Índice de Pacotes Python <https://pypi.python.org/pypi>`_, também conhecido
-como `PyPI` ou "A Loja de Queijo", é um repositório central para códigos Python.
+como `PyPI` ou "The Cheese Shop", é um repositório central para códigos Python.
 Muitos projetos BeeWare podem ser instalados usando 'pip'. 
 
-Porque ele é chamado de "A Loja de Queijo"? esta é uma referência do `Monty
+Porque ele é chamado de "The Cheese Shop"? esta é uma referência do `Monty
 Python <https://www.youtube.com/watch?v=cWDdd5KKhts>`_ :)
 
 ---

--- a/content/contributing/how/contents+pt.lr
+++ b/content/contributing/how/contents+pt.lr
@@ -3,8 +3,8 @@ body:
 Aqui é onde o guia de contribuição para o BeeWare eventualmente virá. Nós não temos uma política de procedimentos concretas ainda - mas sabemos 
 que elas são realmente importantes e temos intenção de escreve-las em breve.
 
-No meio tempo: Sigam a `PEP8 <https://www.python.org/dev/peps/pep-0008/>`__ (prestando bastante atenção a `Seção 2 <https://www.python.org/dev/peps/pep-0008/#a-foolish-consistency-is-the-hobgoblin-of-little-minds>`__),  e os procedimentos padrões de fazer forking
-do GitHub. Nós vamos trabalhar no resto enquanto isso.
+No meio tempo: Sigam a `PEP8 <https://www.python.org/dev/peps/pep-0008/>`__ (prestando bastante atenção a `Seção 2 <https://www.python.org/dev/peps/pep-0008/#a-foolish-consistency-is-the-hobgoblin-of-little-minds>`__),  e os procedimentos padrões de como fazer um 
+forking do GitHub. Nós vamos trabalhar no resto enquanto isso.
 
 
 
@@ -14,15 +14,15 @@ Assine seu trabalho
 Antes de nós podermos aceitar sua contribuição no BeeWare, você precisa nos dar permissão para faze-lo. Já que você é um autor de um trabalho
 criativo (um pedaço de código, ou alguma documentação), você automaticamente detêm os direitos desse trabalho. BeeWare não pode usar sua contribuição legalmente a menos que você nos dê permissão para faze-lo.
 
-O projeto BeeWare usa um mecanismo conhecido como um `Certificado de Origem do Desenvolvedor(COD) <./dco/>`__ para admnistrar esse processo. O COD é uma declaração legal obrigatória que atesta que você é o criador de uma contribuição e que você permite que o BeeWare use o seu trabalho.
+O projeto BeeWare usa um mecanismo conhecido como um `Certificado de Origem do Desenvolvedor(DCO) <./dco/>`__ para admnistrar esse processo. O DCO é uma declaração legal obrigatória que atesta que você é o criador de uma contribuição e que você permite que o BeeWare use o seu trabalho.
 
-Para indicar que você concorda com os termos do COD, você precisa adicionar uma linha em todas suas mensagens de commit::
+Para indicar que você concorda com os termos do DCO, você precisa adicionar uma linha em todas suas mensagens de commit::
 
     Signed-off-by: Joe Smith <joe.smith@email.com>
 
 Se você configurou seu ``user.name`` e ``user.email`` na sua configuração do git, você pode assinar seu commit automaticamente com ``git commit -s``.
 
-Se você tem mais perguntas sobre o COD, porque ele é necessário, o que significa e como configurar seu sistema para usa-lo, veja `Guia do Iniciante do COD <./dco/>`__, ou `entre em contato com o time de desenvolvimento </community/team>`__.
+Se você tem mais perguntas sobre o DCO, porque ele é necessário, o que significa e como configurar seu sistema para usa-lo, veja `Guia do Iniciante do DCO <./dco/>`__, ou `entre em contato com o time de desenvolvimento </community/team>`__.
 
 ---
 incomplete: yes

--- a/content/contributing/what/contents+pt.lr
+++ b/content/contributing/what/contents+pt.lr
@@ -27,7 +27,7 @@ patch para algum desses problemas.
 Uso da Plataforma
 ---------------------
 
-Você usa Windows ou algum "sabor" de Linux? Você consegue instalar um projeto ou uma aplicação no seu sistema? Você encontrou algum problema?
+Você usa Windows ou algum "flavor" de Linux? Você consegue instalar um projeto ou uma aplicação no seu sistema? Você encontrou algum problema?
 
 Se sim, por favor atualize a documentação para mostrar como você fez para faze-lo funcionar, ou relate uma issue se você encontrou um bug que não pode consertar.
 


### PR DESCRIPTION
translated the "http://pybee.org/contributing/core-team/" to pt_BR

Signed-off-by: Carlos Henrique <azengard@users.noreply.github.com>

A disclaimer about this page: 
It was a difficult one, there are so many playwords on this text and chose if it's better to keep the joke or to chose for a word who explain better the idea of the text was a problem.
After i rewrite many times some paragraphs i realize that probably i will keep stuck on this page, so i choose send it, that way i can keep translating the rest of the site. And someone else can make it better.
I am not sure yet if it's better to keep the original word in some cases (and put a translation note) or translate it anyway looking for a better global understanding of the subject.
Anyway, the core of this page are still there in the translated one, i was able too explain that are different levels for contributing on this project and what rights and responsibilities each level has.
But the Bee-nevolent joke was lost :(