### PR TITLE
Include event type in listings

### DIFF
--- a/content/news/events/djangocon-europe-2017-sprints/contents.lr
+++ b/content/news/events/djangocon-europe-2017-sprints/contents.lr
@@ -1,4 +1,4 @@
-title: DjangoCon Europe 2017 Sprints
+title: DjangoCon Europe 2017
 ---
 date: 2017-04-06
 ---

--- a/content/news/events/pycon-us-2017-km/contents.lr
+++ b/content/news/events/pycon-us-2017-km/contents.lr
@@ -1,4 +1,4 @@
-title: PyCon US 2017 - Batavia Talk
+title: PyCon US 2017
 ---
 date: 2017-05-19
 ---

--- a/content/news/events/pycon-us-2017-rkm/contents.lr
+++ b/content/news/events/pycon-us-2017-rkm/contents.lr
@@ -1,4 +1,4 @@
-title: PyCon US 2017 - VOC Talk
+title: PyCon US 2017
 ---
 date: 2017-05-19
 ---

--- a/content/news/events/pycon-us-2017-sprints/contents.lr
+++ b/content/news/events/pycon-us-2017-sprints/contents.lr
@@ -1,4 +1,4 @@
-title: PyCon US 2017 Sprints
+title: PyCon US 2017
 ---
 date: 2017-05-22
 ---

--- a/content/news/events/pycon-us-2017-tutorials/contents.lr
+++ b/content/news/events/pycon-us-2017-tutorials/contents.lr
@@ -1,4 +1,4 @@
-title: PyCon US 2017 Tutorials
+title: PyCon US 2017
 ---
 date: 2017-05-17
 ---

--- a/content/news/events/pycon-us-2017/contents.lr
+++ b/content/news/events/pycon-us-2017/contents.lr
@@ -1,4 +1,4 @@
-title: PyCon US 2017 Exhibitors Hall
+title: PyCon US 2017
 ---
 date: 2017-05-19
 ---
@@ -10,4 +10,6 @@ upcoming: yes
 ---
 url: https://us.pycon.org/2017/
 ---
-description: Come see us in booth 303 in the exhibitors hall!
+description:
+
+Come see us in booth 303 in the exhibitors hall!

--- a/templates/events.html
+++ b/templates/events.html
@@ -26,11 +26,11 @@
 {% block main %}
 <h2>Upcoming events</h2>
 {% for child in this.children.filter(F.upcoming == True) %}
-<p class="upcoming event" data-date="{{ child.date }}">{{ child.date.strftime("%-d %B %Y") }} <a href="{{ child|url }}">{{ child.title }}</a></p>
+<p class="upcoming event" data-date="{{ child.date }}">{{ child.date.strftime("%-d %B %Y") }} <a href="{{ child|url }}">{{ child.title }} {{ child.event_type}}</a></p>
 {% endfor %}
 <h2>Past events</h2>
 {% for child in this.children.filter(F.upcoming == False).order_by('-date') %}
-<p class="past event" data-date="{{ child.date }}">{{ child.date.strftime("%-d %B %Y") }} <a href="{{ child|url }}">{{ child.title }}</a></p>
+<p class="past event" data-date="{{ child.date }}">{{ child.date.strftime("%-d %B %Y") }} <a href="{{ child|url }}">{{ child.title }} {{child.event_type}}</a></p>
 {% endfor %}
 {% endblock %}
 {% block gutter %}

--- a/templates/news.html
+++ b/templates/news.html
@@ -35,7 +35,7 @@
     <h2><a href="/news/events/">Upcoming events</a></h2>
     <ul>
     {% for child in events %}
-      <li class="upcoming event" data-date="{{ child.date }}">{{ child.date.strftime("%-d %B %Y") }}: <a href="{{ child|url }}">{{ child.title }}</a></li>
+      <li class="upcoming event" data-date="{{ child.date }}">{{ child.date.strftime("%-d %B %Y") }}: <a href="{{ child|url }}">{{ child.title }} {{ child.event_type}}</a></li>
     {% endfor %}
     </ul>
   </div>


### PR DESCRIPTION
This could be better formatted, at least on the full events listing page, using similar logic to the news ticket on the front page. The sidebar on the news page has limited space, so I've opted for minimal text.