### PR TITLE
Adding missing verb in ouroboros project's name explanation

### DIFF
--- a/content/project/projects/libraries/ouroboros/contents.lr
+++ b/content/project/projects/libraries/ouroboros/contents.lr
@@ -14,6 +14,6 @@ description: A standalone, pure Python implementation of the Python Standard Lib
 ---
 help_required: 
 ---
-pun: The ouroboros is an ancient symbol depicting a serpent its own tail.
+pun: The ouroboros is an ancient symbol depicting a serpent eating its own tail.
 ---
 incomplete: yes


### PR DESCRIPTION
Was missing the `eating` verb.