### PR TITLE
Enable translations for html templates

### DIFF
--- a/databags/incomplete.ini
+++ b/databags/incomplete.ini
@@ -1,0 +1,7 @@
+[en]
+text = This page's contents is incomplete. You can help by
+link_text = expanding it
+
+[pt]
+text = O conteúdo dessa página está incompleto. Você pode
+link_text = expandí-lo

--- a/databags/menu.ini
+++ b/databags/menu.ini
@@ -1,0 +1,15 @@
+[en]
+project = Project
+news = News
+comunity = Comunity
+contributing = Contributing
+contact = Contact
+url_prefix = /
+
+[pt]
+project = Projeto
+news = Notícias
+comunity = Comunidade
+contributing = Contribuir
+contact = Contato
+url_prefix = /pt_BR/

--- a/databags/menu.ini
+++ b/databags/menu.ini
@@ -4,6 +4,7 @@ news = News
 comunity = Comunity
 contributing = Contributing
 contact = Contact
+languages = Languages
 url_prefix = /
 
 [pt]
@@ -12,4 +13,5 @@ news = Notícias
 comunity = Comunidade
 contributing = Contribuir
 contact = Contato
+languages = Idiomas
 url_prefix = /pt_BR/

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -49,21 +49,22 @@ ga('send', 'pageview');
         </button>
         <div class="collapse navbar-toggleable-sm" id="collapsingNavbar">
           <a class="navbar-brand" href="/">BeeWare</a>
+          {% set url_prefix = bag('menu', this.alt, 'url_prefix') %}
           <ul class="nav navbar-nav">
             <li class="nav-item{% if this.is_child_of('/project') %} active{% endif %}">
-              <a class="nav-link" href="/project/">Project{% if this.is_child_of('/project') %}<span class="sr-only">(current)</span>{% endif %}</a>
+              <a class="nav-link" href="{{ url_prefix }}project/">{{ bag('menu', this.alt, 'project') }}{% if this.is_child_of('/project') %}<span class="sr-only">(current)</span>{% endif %}</a>
             </li>
             <li class="nav-item{% if this.is_child_of('/news') %} active{% endif %}">
-              <a class="nav-link" href="/news/">News{% if this.is_child_of('/news') %}<span class="sr-only">(current)</span>{% endif %}</a>
+              <a class="nav-link" href="{{ url_prefix }}news/">{{ bag('menu', this.alt, 'news') }}{% if this.is_child_of('/news') %}<span class="sr-only">(current)</span>{% endif %}</a>
             </li>
             <li class="nav-item{% if this.is_child_of('/community') %} active{% endif %}">
-              <a class="nav-link" href="/community/">Community{% if this.is_child_of('/community') %}<span class="sr-only">(current)</span>{% endif %}</a>
+              <a class="nav-link" href="{{ url_prefix }}community/">{{ bag('menu', this.alt, 'comunity') }}{% if this.is_child_of('/community') %}<span class="sr-only">(current)</span>{% endif %}</a>
             </li>
             <li class="nav-item{% if this.is_child_of('/contributing') %} active{% endif %}">
-              <a class="nav-link" href="/contributing/">Contributing{% if this.is_child_of('/contributing') %}<span class="sr-only">(current)</span>{% endif %}</a>
+              <a class="nav-link" href="{{ url_prefix }}contributing/">{{ bag('menu', this.alt, 'contributing') }}{% if this.is_child_of('/contributing') %}<span class="sr-only">(current)</span>{% endif %}</a>
             </li>
             <li class="nav-item{% if this.is_child_of('/contact') %} active{% endif %}">
-              <a class="nav-link" href="/contact/">Contact{% if this.is_child_of('/contact') %}<span class="sr-only">(current)</span>{% endif %}</a>
+              <a class="nav-link" href="{{ url_prefix }}contact/">{{ bag('menu', this.alt, 'contact') }}{% if this.is_child_of('/contact') %}<span class="sr-only">(current)</span>{% endif %}</a>
             </li>
           </ul>
         </div>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -66,6 +66,14 @@ ga('send', 'pageview');
             <li class="nav-item{% if this.is_child_of('/contact') %} active{% endif %}">
               <a class="nav-link" href="{{ url_prefix }}contact/">{{ bag('menu', this.alt, 'contact') }}{% if this.is_child_of('/contact') %}<span class="sr-only">(current)</span>{% endif %}</a>
             </li>
+            <li class="nav-item dropdown">
+              <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">{{ bag('menu', this.alt, 'languages') }} <span class="caret"></span></a>
+              <ul class="dropdown-menu bg-inverse">
+                {% for alt, alternative in config.ALTERNATIVES.iteritems() %}
+                  <li class="p-l-1"><a class="nav-link" href="{{ '.'|url(alt=alt) }}">{{ alternative.name.en }}</a></li>
+                {% endfor %}
+              </ul>
+            </li>
           </ul>
         </div>
       </div>

--- a/templates/macros/incomplete.html
+++ b/templates/macros/incomplete.html
@@ -1,5 +1,8 @@
 {% macro incomplete(page) %}
   {% if page.incomplete %}
-  <p class="incomplete"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> This page's contents is incomplete. You can help by <a href="https://github.com/pybee/pybee.github.io/edit/lektor/content{{ page.path }}/contents.lr">expanding it.</a></p>
+  <p class="incomplete">
+      <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+      {{ bag('incomplete', page.alt, 'text') }} <a href="https://github.com/pybee/pybee.github.io/edit/lektor/content{{ page.path }}/contents.lr">{{ bag('incomplete', page.alt, 'link_text') }}</a>.
+  </p>
   {% endif %}
 {% endmacro %}


### PR DESCRIPTION
Using jinja feature, check language and enable translation for incomplete message and menu in the templates.
English remain as the fallback/standard language.