### PR TITLE
PR: Add showcase option to project model and adapt home template

### DIFF
--- a/content/project/projects/bridges/batavia/contents.lr
+++ b/content/project/projects/bridges/batavia/contents.lr
@@ -53,3 +53,5 @@ The wreck of the Batavia was recovered in the 1970s, and now stands in the
 rtfd_name: batavia
 ---
 customlogo: yes
+---
+showcase: yes

--- a/content/project/projects/bridges/voc/contents.lr
+++ b/content/project/projects/bridges/voc/contents.lr
@@ -68,3 +68,5 @@ It's your choice.
 rtfd_name: voc
 ---
 customlogo: yes
+---
+showcase: yes

--- a/content/project/projects/libraries/toga/contents.lr
+++ b/content/project/projects/libraries/toga/contents.lr
@@ -60,3 +60,5 @@ pun: When in Rome, do as the Romans do. And what does a Roman wear? A Toga!
 rtfd_name: toga
 ---
 customlogo: yes
+---
+showcase: yes

--- a/content/project/projects/tools/briefcase/contents.lr
+++ b/content/project/projects/tools/briefcase/contents.lr
@@ -10,7 +10,9 @@ platforms: macOS, iOS, android, tvOS, windows
 ---
 short_description: Tools to support converting a Python project into a standalone native application.
 ---
-description: A distutils extension to assist in packaging Python projects as standalone applications.
+description:
+
+A distutils extension to assist in packaging Python projects as standalone applications.
 
 Briefcase is a tool for converting a Python project into a standalone native application. You can package projects for:
 
@@ -45,3 +47,5 @@ incomplete: yes
 rtfd_name: briefcase
 ---
 customlogo: yes
+---
+showcase: yes

--- a/content/project/projects/tools/cricket/contents.lr
+++ b/content/project/projects/tools/cricket/contents.lr
@@ -41,3 +41,5 @@ something else is required...
 rtfd_name: cricket
 ---
 customlogo: yes
+---
+showcase: yes

--- a/models/project.ini
+++ b/models/project.ini
@@ -73,3 +73,8 @@ type = boolean
 label = Does this project have a custom logo?
 width = 1/4
 type = boolean
+
+[fields.showcase]
+label = Showcase this projects on home page?
+width = 1/4
+type = boolean

--- a/templates/home.html
+++ b/templates/home.html
@@ -134,27 +134,17 @@
     <hr/>
 
     <h2><a href="/project/projects/">Projects</a></h2>
+    {% set project_types = site.query('/project/projects') %}
+    {% for project_type in project_types %}
+    {%   for project in site.query(project_type.path).filter(F.showcase==True) %}
     <div>
-      <h4><a href="/project/projects/libraries/toga"><img src="/project/projects/libraries/toga/toga.png" height="32px" alt="Toga"> Toga</h4></a>
-      <p>A native widget toolkit<br/>for desktop and mobile</p>
+      <h4><a href="{{project.path}}"><img src="{{project.path}}/{{ project.name|lower }}.png" height="32px" alt="{{ project.name }}"> {{ project.name }}</h4></a>
+      {{ project.short_description|string|wordwrap(width=40, wrapstring='<br>')|safe }}
     </div>
-    <div>
-      <h4><a href="/project/projects/bridges/voc"><img src="/project/projects/bridges/voc/voc.png" height="32px" alt="VOC"> VOC</a></h4>
-      <p>Run your Python code<br/>on a Java virtual machine</p>
-    </div>
-    <div>
-      <h4><a href="/project/projects/tools/briefcase"><img src="/project/projects/tools/briefcase/briefcase.png" height="32px" alt="Briefcase"> Briefcase</a></h4>
-      <p>Package your Python code<br/>as a native app</p>
-    </div>
-    <div>
-      <h4><a href="/project/projects/bridges/batavia"><img src="/project/projects/bridges/batavia/batavia.png" height="32px" alt="Batavia"> Batavia</a></h4>
-      <p>Run your Python code<br/>in the browser</p>
-    </div>
-    <div>
-      <h4><a href="/project/projects/tools/cricket"><img src="/project/projects/tools/cricket/cricket.png" height="32px" alt="Cricket"> Cricket</a></h4>
-      <p>Manage unit testing<br/>with a graphical interface</p>
-    </div>
+    {%   endfor %}
+    {% endfor %}
     <h3><a href="/project/projects/">... and many more</a></h3>
+
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
Related to  #157 

--- 

@freakboy3742 working with the translations of Spanish, I found some things are hardcoded, this is making the projects a bit more flexible, which also will adapt as alternatives are added.

I am looping through projects types and projects, so the order is based on that, which changes with the current ordering. Would this be an issue?

## Looks
<img width="1419" alt="screen shot 2017-07-24 at 15 52 14" src="https://user-images.githubusercontent.com/3627835/28544274-3da68b5e-7088-11e7-81f9-e8b7941ba5b1.png">

## Admin interface
<img width="845" alt="screen shot 2017-07-24 at 15 52 41" src="https://user-images.githubusercontent.com/3627835/28544281-3f3fec08-7088-11e7-9c32-bd3323516395.png">


---

Next PR is making flowblocks for the content in the home (text + image (optional) + button (optional))