### PR TITLE
Refactor translation in templates

### DIFF
--- a/databags/incomplete.ini
+++ b/databags/incomplete.ini
@@ -1,7 +1,16 @@
 [en]
-text = This page's contents is incomplete. You can help by
+before_link_text = This page's contents is incomplete. You can help by
 link_text = expanding it
+after_link_text = .
+space_before_link = true
+space_after_link = false
 
 [pt]
-text = O conteúdo dessa página está incompleto. Você pode
+before_link_text = O conteúdo dessa página está incompleto. Você pode
 link_text = expandí-lo
+
+[zh]
+before_link_text = 這個頁面的內容尚未翻譯完成。請協助
+link_text = 貢獻翻譯
+after_link_text = 。
+space_before_link = false

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,6 +1,9 @@
-{% macro menu_item(parent, identifier) %}
-<li class="nav-item{% if this.is_child_of(parent) %} active{% endif %}">
-  <a class="nav-link" href="{{ url_prefix }}project/">{{ bag('menu', this.alt, identifier)|default(bag('menu', 'en', identifier), true) }}{% if this.is_child_of(parent) %}<span class="sr-only">(current)</span>{% endif %}</a>
+{% from 'macros/translation.html' import transbag %}
+
+{% macro menu_item(identifier) %}
+{% set this_is_child = this.is_child_of('/' + identifier) %}
+<li class="nav-item{% if this_is_child %} active{% endif %}">
+  <a class="nav-link" href="{{ transbag('menu', this.alt, 'url_prefix') }}{{ identifier }}/">{{ transbag('menu', this.alt, identifier) }}{% if this_is_child %}<span class="sr-only">(current)</span>{% endif %}</a>
 </li>
 {% endmacro %}
 
@@ -55,17 +58,16 @@ ga('send', 'pageview');
         </button>
         <div class="collapse navbar-toggleable-sm" id="collapsingNavbar">
           <a class="navbar-brand" href="/">BeeWare</a>
-          {% set url_prefix = bag('menu', this.alt, 'url_prefix') %}
           <ul class="nav navbar-nav">
-            {{ menu_item('/project', 'project') }}
-            {{ menu_item('/news', 'news') }}
-            {{ menu_item('/community', 'community') }}
-            {{ menu_item('/contributing', 'contributing') }}
-            {{ menu_item('/contact', 'contact') }}
+            {{ menu_item('project') }}
+            {{ menu_item('news') }}
+            {{ menu_item('community') }}
+            {{ menu_item('contributing') }}
+            {{ menu_item('contact') }}
             <li class="nav-item dropdown">
-              <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">{{ bag('menu', this.alt, 'languages')|default(bag('menu', 'en', 'languages'), true) }} <span class="caret"></span></a>
+              <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">{{ transbag('menu', this.alt, 'languages') }} <span class="caret"></span></a>
               <ul class="dropdown-menu bg-inverse">
-                {% for alt, alternative in config.ALTERNATIVES.iteritems() %}
+                {% for alt, alternative in config.ALTERNATIVES.items() %}
                   <li class="p-l-1"><a class="nav-link" href="{{ '.'|url(alt=alt) }}">{{ alternative.name.en }}</a></li>
                 {% endfor %}
               </ul>

--- a/templates/macros/incomplete.html
+++ b/templates/macros/incomplete.html
@@ -1,8 +1,10 @@
+{% from 'macros/translation.html' import transbag %}
+
 {% macro incomplete(page) %}
   {% if page.incomplete %}
   <p class="incomplete">
       <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
-      {{ bag('incomplete', page.alt, 'text') }} <a href="https://github.com/pybee/pybee.github.io/edit/lektor/content{{ page.path }}/contents.lr">{{ bag('incomplete', page.alt, 'link_text') }}</a>.
+      {{ transbag('incomplete', page.alt, 'before_link_text').strip() }}{% if transbag('incomplete', page.alt, 'space_before_link').strip() == 'true' %} {% endif %}<a href="https://github.com/pybee/pybee.github.io/edit/lektor/content{{ page.path }}/contents.lr">{{ transbag('incomplete', page.alt, 'link_text').strip() }}</a>{% if transbag('incomplete', page.alt, 'space_after_link').strip() == 'true' %} {% endif %}{{ transbag('incomplete', page.alt, 'after_link_text').strip() }}
   </p>
   {% endif %}
 {% endmacro %}

--- a/templates/macros/translation.html
+++ b/templates/macros/translation.html
@@ -1,0 +1,3 @@
+{% macro transbag(bag_name, alt, key, alt_default='en') %}
+{{ bag(bag_name, alt, key)|default(bag(bag_name, alt_default, key), true) }}
+{% endmacro %}


### PR DESCRIPTION
Found some other problems when translating the site. This PR

1. Adds macro `transbag()` to handle the language fallback logic.
2. Uses the `transbag()` macro in places where the fallback logic is needed,
   including incomplete() and menu_item() macros.
3. Rewrites the `incomplete()` macro to handle non-Roman languages better.
4. Add incomplete databag for Chinese to demostrate the difference.

All the above produce in the following result. Notice the lack of spaces around the link:

![screen shot 2017-07-25 at 17 58 48](https://user-images.githubusercontent.com/605277/28566852-f9585410-7162-11e7-9f84-24a357a587a9.png)
