### PR TITLE
Add |url to fix link in the button flowblock

### DIFF
--- a/templates/blocks/button-block.html
+++ b/templates/blocks/button-block.html
@@ -1,1 +1,1 @@
-<a class="btn btn-{{ this.type }} btn-{{ this.size }} {% if this.is_block %}btn-block{% endif %}" href="{{ this.link }}" role="button">{% if this.icon %}<i class="fa fa-{{ this.icon }}" aria-hidden="true"></i> {% endif %}{{ this.label }}</a>
+<a class="btn btn-{{ this.type }} btn-{{ this.size }} {% if this.is_block %}btn-block{% endif %}" href="{{ this.link|url }}" role="button">{% if this.icon %}<i class="fa fa-{{ this.icon }}" aria-hidden="true"></i> {% endif %}{{ this.label }}</a>


### PR DESCRIPTION
Also you don’t really need pass `alt=this.alt` to the `url` filter. According to the [documentation](https://www.getlektor.com/docs/templates/urls/#url-filter) it picks up the current alt is picked up automatically. (But [`.query()` does not](https://www.getlektor.com/docs/api/db/pad/query/), and defaults to the primary alt, which is arguably a bug in Lektor…?) In any case passing the alt explicitly (as currently done in many places) won’t break anything either.