### PR TITLE
Show incomplete banner if falling back to English

### DIFF
--- a/packages/.gitignore
+++ b/packages/.gitignore
@@ -1,0 +1,5 @@
+dist
+build
+*.pyc
+*.pyo
+*.egg-info

--- a/packages/pybee/lektor_pybee.py
+++ b/packages/pybee/lektor_pybee.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+
+from lektor.pluginsystem import Plugin
+
+
+def is_using_fallback_alt(page):
+    alt_basename = 'contents+{alt}.lr'.format(alt=page.alt)
+    return (
+        os.path.basename(page.source_filename) != alt_basename or
+        not os.path.exists(page.source_filename)
+    )
+
+
+class PyBeePlugin(Plugin):
+    """Plugin entry providing useful extensions for `pybee.org`.
+    """
+    name = 'PyBee'
+    description = u'Useful extensions for pybee.org.'
+
+    def on_setup_env(self, **extra):
+        self.env.jinja_env.filters.update({
+            'is_using_fallback_alt': is_using_fallback_alt,
+        })

--- a/packages/pybee/setup.py
+++ b/packages/pybee/setup.py
@@ -1,0 +1,15 @@
+from setuptools import setup
+
+setup(
+    name='lektor-pybee',
+    version='0.1',
+    author='Tzu-ping Chung',
+    author_email='uranusjr@gmail.com',
+    license='MIT',
+    py_modules=['lektor_pybee'],
+    entry_points={
+        'lektor.plugins': [
+            'pybee = lektor_pybee:PyBeePlugin',
+        ]
+    }
+)

--- a/templates/macros/incomplete.html
+++ b/templates/macros/incomplete.html
@@ -1,7 +1,7 @@
 {% from "macros/translation.html" import transbag %}
 
 {% macro incomplete(page) %}
-  {% if page.incomplete %}
+  {% if page.incomplete or page|is_using_fallback_alt %}
   {% set t_text = transbag('translate', page.alt, 'incomplete_text').strip() %}
   {% set t_link = transbag('translate', page.alt, 'incomplete_link').strip() %}
   {% set t_after = transbag('translate', page.alt, 'incomplete_after_link_text').strip() %}


### PR DESCRIPTION
The current (without this PR) behaviour shows the incomplete banner when there is an alt marked as incomplete, but not when the alt is completely absent (Lektor fallbacks to the default contents.lr in this case). This adds a custom filter in Jinja2 to detect this case, and shows the incomplete banner.