### PR TITLE
Fix empty gutter block

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -27,7 +27,7 @@
   {% endblock %}
   </div>
   {% block gutter %}
-    {% if this.gutter %}
+    {% if this.gutter and this.gutter.source %}
   <div class="col-sm-12 col-md-4 gutter">
     {{ this.gutter }}
   </div>


### PR DESCRIPTION
An empty sidebar is shown when gutter is empty (or missing) because the Rst object still evaluates to True. This should probably be reported to lektor-rst as well, but a quick workaround doesn't hurt I guess.