### PR TITLE
PR: Add edit on github link for all pages

### DIFF
--- a/databags/translate.ini
+++ b/databags/translate.ini
@@ -1,7 +1,8 @@
 [en]
 ; Breadcrumbs
 home = Home
-
+edit_on_github = Edit on GitHub
+ 
 ; Footer
 sitemap = Sitemap
 
@@ -116,6 +117,7 @@ incomplete_space_before_link = false
 [es]
 ; Breadcrumbs
 home = Inicio
+edit_on_github = Editar en GitHub
 
 ; Footer
 sitemap = Mapa del Sitio

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -12,6 +12,7 @@
 {% set t_languages = transbag('menu', this.alt, 'languages') %}
 {% set t_sitemap = transbag('translate', this.alt, 'sitemap') %}
 {% set t_welcome = transbag('translate', this.alt, 'welcome') %}
+{% set t_edit_on_github = transbag('translate', this.alt, 'edit_on_github') %}
 
 <!DOCTYPE html>
 <html lang="en">
@@ -82,6 +83,16 @@ ga('send', 'pageview');
           {% endfor %}
         </div>
       </li>
+    </ul>
+    <ul class="nav navbar-nav navbar-right">
+        {% set extra_slash = '/' if this.path[-1] != '/' else '' %}
+        {% set alt_path = '+' + this.alt if this.alt and this.alt != 'en' else '' %}
+        {# set trans_available = this.contents != site.get(this.path).contents.as_text() #}
+        <li class="small">
+          <a href="https://github.com/pybee/pybee.github.io/edit/lektor/content{{ this.path }}{{ extra_slash }}contents{{ alt_path }}.lr">
+            <i class="fa fa-github "></i><small>{{ t_edit_on_github }}</small>
+          </a>
+        </li>
     </ul>
   </div>
   </nav>


### PR DESCRIPTION
Fixes #191 

---

This has an issue for pages that do not exist on gihtub, like alternatives that are not yet there for some pages (in which the default lang is used). There seems to be no way to check this currently on Lektor, but I opened an issue to track this [here](https://github.com/lektor/lektor/issues/459)

This is how the link looks

<img width="1424" alt="screen shot 2017-09-25 at 11 57 48" src="https://user-images.githubusercontent.com/3627835/30818237-ffc09446-a1e8-11e7-9feb-a4244c320dd7.png">
