### PR TITLE
PR: Check alt file existence plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *~
 .DS_Store
+*.egg-info/
+*.pyc

--- a/databags/translate.ini
+++ b/databags/translate.ini
@@ -2,6 +2,7 @@
 ; Breadcrumbs
 home = Home
 edit_on_github = Edit on GitHub
+create_on_github = Translate on GitHub
  
 ; Footer
 sitemap = Sitemap
@@ -118,6 +119,7 @@ incomplete_space_before_link = false
 ; Breadcrumbs
 home = Inicio
 edit_on_github = Editar en GitHub
+create_on_github = Traducir en GitHub
 
 ; Footer
 sitemap = Mapa del Sitio

--- a/packages/lektor_pybee_plugin/lektor_pybee_plugin.py
+++ b/packages/lektor_pybee_plugin/lektor_pybee_plugin.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+"""This is a custom local plugin to ad extra functionality to pybee site."""
+
+# Third party imports
+from lektor.pluginsystem import Plugin
+from lektor.db import Record
+
+
+class PyBeePlugin(Plugin):
+    name = 'PyBee Custom Lektor Plugin'
+    description = 'This is a custom local plugin to ad extra functionality.'
+
+    def on_setup_env(self, **extra):
+
+        def is_alt_content_available(record):
+            """Checks if record path (content+<alt>.lr) file exists."""
+            if not isinstance(record, Record):
+                raise ValueError('Must provide a `Record` object')
+
+            alt_available = True
+            config = self.env.jinja_env.globals['config']
+            if record.alt != config.primary_alternative:
+                try:
+                    record.contents.as_text()
+                except IOError:
+                    # This means the alt content file does not exist
+                    alt_available = False
+
+            return alt_available
+
+        self.env.jinja_env.globals.update(
+            is_alt_content_available=is_alt_content_available
+        )

--- a/packages/lektor_pybee_plugin/lektor_pybee_plugin.py
+++ b/packages/lektor_pybee_plugin/lektor_pybee_plugin.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 """This is a custom local plugin to ad extra functionality to pybee site."""
+# Standrd library imports
+import urllib
 
 # Third party imports
 from lektor.pluginsystem import Plugin
 from lektor.db import Record
+from markupsafe import Markup
 
 
 class PyBeePlugin(Plugin):
@@ -28,6 +31,21 @@ class PyBeePlugin(Plugin):
 
             return alt_available
 
+        def urlencode_limit(string, limit=6000):
+            """Encodes url for uri but if over limit returns None"""
+            if type(string) == 'Markup':
+                string = string.unescape()
+
+            if len(string) <= limit:
+                string = string.encode('utf8')
+                string = urllib.quote_plus(string)
+                string = Markup(string)
+            else:
+                string = None
+
+            return string
+
         self.env.jinja_env.globals.update(
             is_alt_content_available=is_alt_content_available
         )
+        self.env.jinja_env.globals.update(urlencode_limit=urlencode_limit)

--- a/packages/lektor_pybee_plugin/setup.py
+++ b/packages/lektor_pybee_plugin/setup.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+"""This is a custom local plugin to ad extra functionality to pybee site."""
+
+# Third party imports
+from setuptools import setup
+
+
+setup(
+    name='lektor-pybee-plugin',
+    author='Gonzalo Peña-Castellanos',
+    author_email='goanpeca@gmail.com',
+    url='https://github.com/pybee/pybee.github.io/tree/lektor/packages/lektor_pybee_plugin',
+    version='0.1',
+    license='MIT',
+    py_modules=['lektor_pybee_plugin'],
+    entry_points={
+        'lektor.plugins': [
+            'pybee-plugin = lektor_pybee_plugin:PyBeePlugin',
+        ]
+    }
+)

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -77,7 +77,7 @@ ga('send', 'pageview');
           <a class="dropdown-item {% if eng_active %}active{% endif %}" href="{{ '.'|url(alt='en') }}">English</a>
           {% for alt, alternative in config.ALTERNATIVES.items()|sort %}
           {% set alt_active = alt == this.alt %}
-          {% if alt != 'en' %}
+          {% if alt != config.primary_alternative %}
           <a class="dropdown-item {% if alt_active %}active{% endif %}" href="{{ '.'|url(alt=alt) }}">{{ alternative.name.en }}</a>
           {% endif %}
           {% endfor %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -84,16 +84,20 @@ ga('send', 'pageview');
         </div>
       </li>
     </ul>
+    {# This method is provided by a custom plugin found in /packages/lektor_pybee_plugin/ #}
+    {% if is_alt_content_available('hello') %}
+    {% endif %}
+    {% if is_alt_content_available(this) %}
     <ul class="nav navbar-nav navbar-right">
         {% set extra_slash = '/' if this.path[-1] != '/' else '' %}
         {% set alt_path = '+' + this.alt if this.alt and this.alt != 'en' else '' %}
-        {# set trans_available = this.contents != site.get(this.path).contents.as_text() #}
         <li class="small">
           <a href="https://github.com/pybee/pybee.github.io/edit/lektor/content{{ this.path }}{{ extra_slash }}contents{{ alt_path }}.lr">
             <i class="fa fa-github "></i><small>{{ t_edit_on_github }}</small>
           </a>
         </li>
     </ul>
+    {% endif %}
   </div>
   </nav>
 

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -85,8 +85,6 @@ ga('send', 'pageview');
       </li>
     </ul>
     {# This method is provided by a custom plugin found in /packages/lektor_pybee_plugin/ #}
-    {% if is_alt_content_available('hello') %}
-    {% endif %}
     {% if is_alt_content_available(this) %}
     <ul class="nav navbar-nav navbar-right">
         {% set extra_slash = '/' if this.path[-1] != '/' else '' %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -13,6 +13,7 @@
 {% set t_sitemap = transbag('translate', this.alt, 'sitemap') %}
 {% set t_welcome = transbag('translate', this.alt, 'welcome') %}
 {% set t_edit_on_github = transbag('translate', this.alt, 'edit_on_github') %}
+{% set t_create_on_github = transbag('translate', this.alt, 'create_on_github') %}
 
 <!DOCTYPE html>
 <html lang="en">
@@ -84,21 +85,28 @@ ga('send', 'pageview');
         </div>
       </li>
     </ul>
-    {# This method is provided by a custom plugin found in /packages/lektor_pybee_plugin/ #}
-    {% if is_alt_content_available(this) %}
     <ul class="nav navbar-nav navbar-right">
         {% set extra_slash = '/' if this.path[-1] != '/' else '' %}
-        {% set alt_path = '+' + this.alt if this.alt and this.alt != 'en' else '' %}
+        {% set alt_path = '%2B' + this.alt if this.alt and this.alt != 'en' else '' %}
         <li class="small">
-          <a href="https://github.com/pybee/pybee.github.io/edit/lektor/content{{ this.path }}{{ extra_slash }}contents{{ alt_path }}.lr">
-            <i class="fa fa-github "></i><small>{{ t_edit_on_github }}</small>
+        {# This method is provided by a custom plugin found in /packages/lektor_pybee_plugin/ #}
+        {% if is_alt_content_available(this) %}
+          <a href="https://github.com/pybee/pybee.github.io/edit/lektor/content{{ this.path }}{{ extra_slash }}contents{{ alt_path }}.lr" target="_blank">
+            <i class="fa fa-github "></i><small>&nbsp;{{ t_edit_on_github }}</small>
           </a>
+        {% else %}
+          {# This method is provided by a custom plugin found in /packages/lektor_pybee_plugin/ #}
+          {% set content_value = urlencode_limit(site.get(this.path).contents.as_text(), limit=5000) %}
+          {% if content_value and '@' not in this.path %}
+          <a href="https://github.com/pybee/pybee.github.io/new/lektor/content{{ this.path }}/contents{{ alt_path }}.lr?filename=contents{{ alt_path }}.lr&value={{ content_value }}" target="_blank">
+            <i class="fa fa-github "></i><small>&nbsp;{{ t_create_on_github }}</small>
+          </a>
+          {% endif %}
+        {% endif %}
         </li>
     </ul>
-    {% endif %}
   </div>
   </nav>
-
     <div class="content">
       {% block preamble %}{% endblock %}
       <div class="container">


### PR DESCRIPTION
This add a plugin so that we only display a `Edit on Github` link on pages that actually have a corresponding `contents+<alt>.lr` file. For files that are not on github and the content is less than 5000 characters, we change it to `Translate on github` which will open a new file creation on github with the content in the primary alt (english in this case). In the case the content is longer than 5000 no link is displayed.

@freakboy3742 what should we display in this case?

---

I could not find another way of doing this, so that is why I created the plugin.

## Edit example
<img width="1414" alt="screen shot 2017-09-26 at 17 05 24" src="https://user-images.githubusercontent.com/3627835/30884268-f7785efa-a2dc-11e7-814f-b889aa6027df.png">

## Translate example
<img width="1412" alt="screen shot 2017-09-26 at 17 05 32" src="https://user-images.githubusercontent.com/3627835/30884267-f74b1c7e-a2dc-11e7-8bdc-f7c1c84e2ebc.png">

## Too long example
<img width="1414" alt="screen shot 2017-09-26 at 17 05 44" src="https://user-images.githubusercontent.com/3627835/30884266-f73fb92e-a2dc-11e7-8990-984fb80bb2b2.png">