### PR TITLE
PR: Fix out of date translations warning and add a modal with diff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,10 @@ cache:
 
 install:
   # Lektor build dependencies
-  - pip install lektor pygments
+  - pip install beautifulsoup4 lektor pygments requests
 
 script:
-  # Only do the checks if this build is the pull request not the merge!
-  - if [[ $TRAVIS_PULL_REQUEST == "true" ]] && [[ $TRAVIS_BRANCH == "lektor" ]]; then
-      "pip install beautifulsoup4 requests"  # Additional test dependencies
-      "python scripts/check_links.py";
-    fi
+  - "python scripts/check_links.py"
   - "lektor plugins reinstall"
   - "lektor build --no-prune"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+# https://travis-ci.org/pybee/pybee.github.io/builds
 language: python
 
 python: 2.7
@@ -8,10 +9,16 @@ cache:
     - $HOME/.cache/lektor/builds
 
 install:
-  - pip install beautifulsoup4 lektor requests
+  # Lektor build dependencies
+  - pip install lektor pygments
 
 script:
-  - "python scripts/check_links.py"
+  # Only do the checks if this build is the pull request not the merge!
+  - if [[ $TRAVIS_PULL_REQUEST == "true" ]] && [[ $TRAVIS_BRANCH == "lektor" ]]; then
+      "pip install beautifulsoup4 requests"  # Additional test dependencies
+      "python scripts/check_links.py";
+    fi
+  - "lektor plugins reinstall"
   - "lektor build --no-prune"
 
 deploy:

--- a/content/project/projects/libraries/colosseum/contents+es.lr
+++ b/content/project/projects/libraries/colosseum/contents+es.lr
@@ -14,7 +14,7 @@ description:
 
 El algoritmo y la suite de pruebas para esta biblioteca es un conversión del proyecto `Yoga`_, creado y distribuido en código abierto por Facebook.
 
-.. _CSS-layout: https://github.com/facebook/yoga
+.. _Yoga: https://github.com/facebook/yoga
 ---
 help_required: 
 ---

--- a/content/project/projects/libraries/colosseum/contents.lr
+++ b/content/project/projects/libraries/colosseum/contents.lr
@@ -15,7 +15,7 @@ description:
 The algorithm and test suite for this library is a language port of
 `Yoga`_ project, open-sourced by Facebook.
 
-.. _CSS-layout: https://github.com/facebook/yoga
+.. _Yoga: https://github.com/facebook/yoga
 ---
 help_required: 
 ---

--- a/databags/translate.ini
+++ b/databags/translate.ini
@@ -4,7 +4,7 @@ home = Home
 edit_on_github = Edit on GitHub
 create_on_github = Translate on GitHub
 translation_out_of_date = This translation of the original content is out of date!
-see_original_content = See original content
+see_original_content = See what changed in the original content
 update_translation = Update translation on Github
  
 ; Footer

--- a/databags/translate.ini
+++ b/databags/translate.ini
@@ -123,8 +123,8 @@ incomplete_space_before_link = false
 home = Inicio
 edit_on_github = Editar en GitHub
 create_on_github = Traducir en GitHub
-translation_out_of_date = El contenido y/o traducción de esta página está desactualizado!
-see_original_content = Ver contenido original
+translation_out_of_date = El contenido y/o traducción de esta página puede estar desactualizado!
+see_original_content = Ver que ha cambiado
 update_translation = Actualizar el contenido en Github
 
 ; Footer

--- a/packages/lektor_pybee_plugin/lektor_pybee_plugin.py
+++ b/packages/lektor_pybee_plugin/lektor_pybee_plugin.py
@@ -26,6 +26,7 @@ class PyBeePlugin(Plugin):
     description = 'This is a custom local plugin to add extra functionality.'
 
     DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
+    EXECUTE_CACHE = {}
 
     def on_setup_env(self, **extra):
 
@@ -33,22 +34,31 @@ class PyBeePlugin(Plugin):
         # ---------------------------------------------------------------------
         def execute(cmd):
             """Execute a cmd (list) and return the stdout and stderr."""
-            stdout, stderr = None, None
-            try:
-                p = subprocess.Popen(cmd, stdout=subprocess.PIPE,
-                                     stderr=subprocess.PIPE)
-                stdout, stderr = p.communicate()
+            joined_cmd = ' '.join(cmd)
+            if joined_cmd in self.EXECUTE_CACHE:
+                stdout, stderr = self.EXECUTE_CACHE[joined_cmd]
+            else:
+                stdout, stderr = None, None
+                try:
+                    p = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                                         stderr=subprocess.PIPE)
+                    stdout, stderr = p.communicate()
 
-                if PY3:
-                    if stdout:
-                        stdout = stdout.decode()
-                    if stderr:
-                        stderr = stderr.decode()
+                    if PY3:
+                        if stdout:
+                            stdout = stdout.decode()
+                        if stderr:
+                            stderr = stderr.decode()
 
-            except OSError:
-                print('\nCommand not found!\n')
-            except Exception as e:
-                print(e)
+                except OSError:
+                    print('\nCommand not found!\n')
+                    print(joined_cmd)
+                    print('\n')
+                except Exception as e:
+                    print(e)
+                    print('\n')
+
+                self.EXECUTE_CACHE[joined_cmd] = (stdout, stderr)
 
             return stdout, stderr
 

--- a/packages/lektor_pybee_plugin/lektor_pybee_plugin.py
+++ b/packages/lektor_pybee_plugin/lektor_pybee_plugin.py
@@ -76,8 +76,7 @@ class PyBeePlugin(Plugin):
 
         def git_diff(filepath, since):
             """Get git diff for a given `filepath` `since` a given date."""
-            diff = None
-
+            html_diff = None
             commits = git_commits(filepath, since)
             if commits:
                 cmd = ('git', '--no-pager', 'diff', commits[-1]+'^', '--',
@@ -86,12 +85,13 @@ class PyBeePlugin(Plugin):
 
                 if stdout:
                     diff = unicode(stdout, 'utf-8')
+                    html_diff = highlight(diff, lexers.DiffLexer(),
+                                          HtmlFormatter())
 
-                # print(' '.join(cmd))
-                # print(diff)
-                # print('\n')
+                    # print(' '.join(cmd))
+                    # print(diff)
+                    # print('\n')
 
-            html_diff = highlight(diff, lexers.DiffLexer(), HtmlFormatter())
             return html_diff
 
         def git_modified_date(filepath):

--- a/packages/lektor_pybee_plugin/lektor_pybee_plugin.py
+++ b/packages/lektor_pybee_plugin/lektor_pybee_plugin.py
@@ -1,23 +1,129 @@
 # -*- coding: utf-8 -*-
 """This is a custom local plugin to ad extra functionality to pybee site."""
-# Standrd library imports
+
+# Standard library imports
+from datetime import datetime
 import os
 import urllib
+import subprocess
+import sys
 
 # Third party imports
 from lektor.pluginsystem import Plugin
 from lektor.db import Record
 from markupsafe import Markup
+from pygments import highlight
+from pygments import lexers
+from pygments.formatters import HtmlFormatter
+from pygments.styles import get_all_styles
+
+
+PY3 = sys.version_info[0] == 3
 
 
 class PyBeePlugin(Plugin):
     name = 'PyBee Custom Lektor Plugin'
-    description = 'This is a custom local plugin to ad extra functionality.'
+    description = 'This is a custom local plugin to add extra functionality.'
+
+    DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
 
     def on_setup_env(self, **extra):
 
-        def is_alt_outdated(record):
-            """Checks if record path (content+<alt>.lr) file exists."""
+        # --- Helper methods
+        # ---------------------------------------------------------------------
+        def execute(cmd):
+            """Execute a cmd (list) and return the stdout and stderr."""
+            stdout, stderr = None, None
+            try:
+                p = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                                     stderr=subprocess.PIPE)
+                stdout, stderr = p.communicate()
+
+                if PY3:
+                    if stdout:
+                        stdout = stdout.decode()
+                    if stderr:
+                        stderr = stderr.decode()
+
+            except OSError:
+                print('\nCommand not found!\n')
+            except Exception as e:
+                print(e)
+
+            return stdout, stderr
+
+        def git_commits(filepath, since):
+            """Get git commit hashes for `filepath` `since` a given date."""
+            cmd = ('git', 'log', '--since="'+since+'"', '--pretty=format:%H',
+                   '--', filepath)
+            stdout, stderr = execute(cmd)
+
+            commits = []
+            if stdout:
+                commits = [c for c in stdout.split('\n') if c]
+
+            return commits
+
+        def git_diff(filepath, since):
+            """Get git diff for a given `filepath` `since` a given date."""
+            diff = None
+
+            commits = git_commits(filepath, since)
+            if commits:
+                cmd = ('git', '--no-pager', 'diff', commits[-1]+'^', '--',
+                       filepath)
+                stdout, stderr = execute(cmd)
+
+                if stdout:
+                    diff = unicode(stdout, 'utf-8')
+
+                # print(' '.join(cmd))
+                # print(diff)
+                # print('\n')
+
+            html_diff = highlight(diff, lexers.DiffLexer(), HtmlFormatter())
+            return html_diff
+
+        def git_modified_date(filepath):
+            """Get last modified date of `filepath` from git."""
+            git_mod_date = None
+
+            if os.path.isfile(filepath):
+                cmd = ('git', 'log', '-1',
+                       '--date=format:"'+self.DATE_FORMAT+'"',
+                       '--format="%ad"', filepath)
+                stdout, stderr = execute(cmd)
+
+                if stdout:
+                    stdout = stdout.split('\n')[0]
+                    stdout = stdout.replace('"', '')
+                    stdout = stdout.replace("'", '')
+
+                if stdout:
+                    git_mod_date = datetime.strptime(stdout, self.DATE_FORMAT)
+
+            # print(' '.join(cmd))
+            # print(git_mod_date)
+            # print('\n')
+
+            return git_mod_date
+
+        # --- Exposed methods
+        # ---------------------------------------------------------------------
+        def get_pygments_css_styles(style='default'):
+            """Get pygments CSS."""
+            class_name = '.highlight'
+            css = None
+            if style in get_all_styles():
+                cmd = ('pygmentize', '-S', style, '-f', 'html', '-a',
+                       class_name)
+                stdout, stderr = execute(cmd)
+                css = '<style>{}</style>'.format(stdout)
+
+            return css
+
+        def alt_outdated_diff(record):
+            """Check if record alternative is outdated and returns the diff."""
             if not isinstance(record, Record):
                 raise ValueError('Must provide a `Record` object')
 
@@ -37,16 +143,23 @@ class PyBeePlugin(Plugin):
 
             primary_modtime = None
             if os.path.isfile(primary_path):
-                primary_modtime = os.path.getmtime(primary_path)
+                # primary_modtime = os.path.getmtime(primary_path)
+                primary_modtime = git_modified_date(primary_path)
 
             alt_modtime = None
             if os.path.isfile(alt_path):
-                alt_modtime = os.path.getmtime(alt_path)
+                # alt_modtime = os.path.getmtime(alt_path)
+                alt_modtime = git_modified_date(alt_path)
 
-            return primary_modtime > alt_modtime
+            diff = None
+            if alt_modtime and primary_modtime > alt_modtime:
+                diff = git_diff(primary_path,
+                                alt_modtime.strftime(self.DATE_FORMAT))
+
+            return diff
 
         def urlencode_limit(string, limit=6000):
-            """Encodes url for uri but if over limit returns None"""
+            """Encodes url for uri but if over limit returns None."""
             if type(string) == 'Markup':
                 string = string.unescape()
 
@@ -59,6 +172,11 @@ class PyBeePlugin(Plugin):
 
             return string
 
-        self.env.jinja_env.globals.update(is_alt_outdated=is_alt_outdated)
+        # Add additional methods to the environment globlas
+        self.env.jinja_env.globals.update(alt_outdated_diff=alt_outdated_diff)
         self.env.jinja_env.globals.update(urlencode_limit=urlencode_limit)
+        self.env.jinja_env.globals.update(
+            get_pygments_css_styles=get_pygments_css_styles)
+
+        # Add some python builtins that are good for debugging
         self.env.jinja_env.globals.update(dir=dir)

--- a/packages/lektor_pybee_plugin/setup.py
+++ b/packages/lektor_pybee_plugin/setup.py
@@ -13,6 +13,7 @@ setup(
     version='0.1',
     license='MIT',
     py_modules=['lektor_pybee_plugin'],
+    install_requires=['Lektor', 'MarkupSafe', 'Pygments'],
     entry_points={
         'lektor.plugins': [
             'pybee-plugin = lektor_pybee_plugin:PyBeePlugin',

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,23 +1,23 @@
-{% from "macros/translation.html" import transbag %}
+{%- from "macros/translation.html" import transbag -%}
 
-{% macro menu_item(identifier) %}
-  {% set identifier_url = '/' + identifier %}
-  {% set trans_url = identifier_url|url(alt=this.alt) %}
-  {% set this_is_child = this.is_child_of(identifier_url) %}
+{%- macro menu_item(identifier) -%}
+  {%- set identifier_url = '/' + identifier -%}
+  {%- set trans_url = identifier_url|url(alt=this.alt) -%}
+  {%- set this_is_child = this.is_child_of(identifier_url) -%}
   <li class="nav-item{% if this_is_child %} active{% endif %}">
-    <a class="nav-link" href="{{ trans_url }}">{{ transbag('menu', this.alt, identifier) }}{% if this_is_child %}<span class="sr-only">(current)</span>{% endif %}</a>
+    <a class="nav-link" href="{{ trans_url }}">{{- transbag('menu', this.alt, identifier) -}}{%- if this_is_child -%}<span class="sr-only">(current)</span>{%- endif -%}</a>
   </li>
-{% endmacro %}
+{%- endmacro -%}
 
-{% set t_languages = transbag('menu', this.alt, 'languages') %}
-{% set t_sitemap = transbag('translate', this.alt, 'sitemap') %}
-{% set t_welcome = transbag('translate', this.alt, 'welcome') %}
-{% set t_edit_on_github = transbag('translate', this.alt, 'edit_on_github') %}
-{% set t_create_on_github = transbag('translate', this.alt, 'create_on_github') %}
-{% set t_translation_out_of_date = transbag('translate', this.alt, 'translation_out_of_date') %}
-{% set t_see_original_content = transbag('translate', this.alt, 'see_original_content') %}
-{% set t_update_translation = transbag('translate', this.alt, 'update_translation') %}
-{% set diff = alt_outdated_diff(this) %}
+{%- set t_languages = transbag('menu', this.alt, 'languages') -%}
+{%- set t_sitemap = transbag('translate', this.alt, 'sitemap') -%}
+{%- set t_welcome = transbag('translate', this.alt, 'welcome') -%}
+{%- set t_edit_on_github = transbag('translate', this.alt, 'edit_on_github') -%}
+{%- set t_create_on_github = transbag('translate', this.alt, 'create_on_github') -%}
+{%- set t_translation_out_of_date = transbag('translate', this.alt, 'translation_out_of_date') -%}
+{%- set t_see_original_content = transbag('translate', this.alt, 'see_original_content') -%}
+{%- set t_update_translation = transbag('translate', this.alt, 'update_translation') -%}
+{%- set diff = alt_outdated_diff(this) -%}
 
 <!DOCTYPE html>
 <html lang="en">
@@ -27,7 +27,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
 
-    <title>{% block title %}{{ t_welcome }}{% endblock %} — BeeWare</title>
+    <title>{%- block title %}{{- t_welcome -}}{% endblock -%} — BeeWare</title>
 
     <!-- Fav and touch icons -->
     <link rel="apple-touch-icon-precomposed" sizes="144x144" href="/static/images/brutus-144.png">
@@ -46,7 +46,7 @@
 
     {%- if diff -%}
     <!-- Project CSS -->
-    {{ get_pygments_css_styles('default')|safe }}
+    {{- get_pygments_css_styles('default')|safe -}}
     {%- endif -%}
 
     <!-- Font Awesome -->
@@ -63,7 +63,7 @@ ga('create', 'UA-2943925-4', 'pybee.org');
 ga('send', 'pageview');
     </script>
 
-    {% block extra_head %}{% endblock %}
+    {%- block extra_head -%}{%- endblock -%}
 
   </head>
   <body>
@@ -83,44 +83,44 @@ ga('send', 'pageview');
      <li class="nav-item dropdown">
         <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">{{ t_languages }} <span class="caret"></span></a>
         <div class="dropdown-menu" aria-labelledby="dropdown01">
-          {% set eng_active = this.alt == 'en' %}
+          {%- set eng_active = this.alt == 'en' %}
           <a class="dropdown-item {% if eng_active %}active{% endif %}" href="{{ '.'|url(alt='en') }}">English</a>
-          {% for alt, alternative in config.ALTERNATIVES.items()|sort %}
-          {% set alt_active = alt == this.alt %}
-          {% if alt != config.primary_alternative %}
+          {%- for alt, alternative in config.ALTERNATIVES.items()|sort -%}
+          {%- set alt_active = alt == this.alt -%}
+          {%- if alt != config.primary_alternative -%}
           <a class="dropdown-item {% if alt_active %}active{% endif %}" href="{{ '.'|url(alt=alt) }}">{{ alternative.name.en }}</a>
-          {% endif %}
-          {% endfor %}
+          {%- endif -%}
+          {%- endfor -%}
         </div>
       </li>
     </ul>
     <ul class="nav navbar-nav navbar-right">
-        {% set extra_slash = '/' if this.path[-1] != '/' else '' %}
-        {% set alt_path = '%2B' + this.alt if this.alt and this.alt != 'en' else '' %}
+        {%- set extra_slash = '/' if this.path[-1] != '/' else '' -%}
+        {%- set alt_path = '%2B' + this.alt if this.alt and this.alt != 'en' else '' -%}
         <li class="small">
-        {% if this.alt in get_alts(source=this, fallback=False) %}
-          {% set edit_link = 'https://github.com/pybee/pybee.github.io/edit/lektor/content' + this.path.split('@')[0] + extra_slash + 'contents' + alt_path + '.lr' %}
+        {%- if this.alt in get_alts(source=this, fallback=False) -%}
+          {%- set edit_link = 'https://github.com/pybee/pybee.github.io/edit/lektor/content' + this.path.split('@')[0] + extra_slash + 'contents' + alt_path + '.lr' -%}
           <a href="{{ edit_link }}" target="_blank">
             <i class="fa fa-github "></i><small>&nbsp;{{ t_edit_on_github }}</small>
           </a>
-        {% else %}
+        {%- else -%}
           {# This method is provided by a custom plugin found in /packages/lektor_pybee_plugin/ #}
-          {% set content_value = urlencode_limit(site.get(this.path).contents.as_text(), limit=5000) %}
-          {% if content_value and '@' not in this.path %}
+          {%- set content_value = urlencode_limit(site.get(this.path).contents.as_text(), limit=5000) -%}
+          {%- if content_value and '@' not in this.path -%}
           <a href="https://github.com/pybee/pybee.github.io/new/lektor/content{{ this.path }}/contents{{ alt_path }}.lr?filename=contents{{ alt_path }}.lr&value={{ content_value }}" target="_blank">
             <i class="fa fa-github "></i><small>&nbsp;{{ t_create_on_github }}</small>
           </a>
-          {% endif %}
-        {% endif %}
+          {%- endif -%}
+        {%- endif -%}
         </li>
     </ul>
   </div>
   </nav>
     <div class="content">
-      {% block preamble %}
-      {% endblock %}
+      {%- block preamble -%}
+      {%- endblock -%}
       <div class="container">
-        {% if this.alt in get_alts(source=this, fallback=False) and diff %}
+        {%- if this.alt in get_alts(source=this, fallback=False) and diff -%}
         <div class="alert alert-warning">
           <i class="fa fa-warning"></i>&nbsp;{{ t_translation_out_of_date }}&nbsp;&nbsp;
           <a href="{{ site.get(this.path)|url }}" data-toggle="modal" data-target="#myModal">{{ t_see_original_content }}</a>
@@ -140,22 +140,22 @@ ga('send', 'pageview');
                   </a>
                 </h4>
               </div>
+              <div class="modal-body">
                 <small>
                 {{- diff|safe -}}
                 </small>
-              <div class="modal-body">
               </div>
               <div class="modal-footer">
                 <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
               </div>
             </div>
-        
+            <!-- End Modal content -->
           </div>
         </div>
-        <!-- End modal -->
+        <!-- End Modal -->
 
-        {% endif %}
-        {% block body %}{% endblock %}
+        {%- endif -%}
+        {%- block body -%}{%- endblock -%}
       </div>
     </div>
 
@@ -177,6 +177,6 @@ ga('send', 'pageview');
     <script src="/static/tether-1.3.3/js/tether.min.js"></script>
     <script src="/static/bootstrap/js/bootstrap.min.js"></script>
 
-    {% block extra_script %}{% endblock %}
+    {%- block extra_script -%}{%- endblock -%}
   </body>
 </html>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -17,6 +17,7 @@
 {% set t_translation_out_of_date = transbag('translate', this.alt, 'translation_out_of_date') %}
 {% set t_see_original_content = transbag('translate', this.alt, 'see_original_content') %}
 {% set t_update_translation = transbag('translate', this.alt, 'update_translation') %}
+{% set diff = alt_outdated_diff(this) %}
 
 <!DOCTYPE html>
 <html lang="en">
@@ -42,6 +43,11 @@
     <!-- Project CSS -->
     <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Cutive">
     <link rel="stylesheet" type="text/css" href="/static/beeware.css">
+
+    {%- if diff -%}
+    <!-- Project CSS -->
+    {{ get_pygments_css_styles('default')|safe }}
+    {%- endif -%}
 
     <!-- Font Awesome -->
     <script src="https://use.fontawesome.com/1138bd8363.js"></script>
@@ -114,11 +120,40 @@ ga('send', 'pageview');
       {% block preamble %}
       {% endblock %}
       <div class="container">
-        {% if this.alt in get_alts(source=this, fallback=False) and is_alt_outdated(this) %}
+        {% if this.alt in get_alts(source=this, fallback=False) and diff %}
         <div class="alert alert-warning">
           <i class="fa fa-warning"></i>&nbsp;{{ t_translation_out_of_date }}&nbsp;&nbsp;
-          <a href="{{ site.get(this.path)|url }}" target="_blank">{{ t_see_original_content }}</a> | <a href="{{ edit_link }}" target="_blank">{{ t_update_translation }}</a>
+          <a href="{{ site.get(this.path)|url }}" data-toggle="modal" data-target="#myModal">{{ t_see_original_content }}</a>
         </div>
+
+        <!-- Modal -->
+        <div id="myModal" class="modal fade" role="dialog">
+          <div class="modal-dialog modal-lg">
+        
+            <!-- Modal content-->
+            <div class="modal-content">
+              <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal">&times;</button>
+                <h4 class="modal-title">
+                  <a href="{{ edit_link }}" target="_blank">
+                    <i class="fa fa-github "></i>&nbsp;{{ t_update_translation }}
+                  </a>
+                </h4>
+              </div>
+                <small>
+                {{- diff|safe -}}
+                </small>
+              <div class="modal-body">
+              </div>
+              <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+              </div>
+            </div>
+        
+          </div>
+        </div>
+        <!-- End modal -->
+
         {% endif %}
         {% block body %}{% endblock %}
       </div>


### PR DESCRIPTION
This fixes the issue of warnings not appearing. Now git commit date is used as the comparison date. Also now we include the diff (in a modal using pygments) since the latest commit based on the last date the alternative was modified.

The 2 links are now replaced by 1 link `See what changed`

<img width="1419" alt="screen shot 2017-09-28 at 14 57 46" src="https://user-images.githubusercontent.com/3627835/30985185-8b3d8c4c-a45d-11e7-8534-988c6a89e010.png">

And now the link to `Update the translation on Github` is on the modal title. On click a new tab will open so the user has one tab, with the modal showing the diff and another tab with the Edit window on Github. I feel this could be improved, but so far was the nicest UI/UX I could think of in short notice.

<img width="1439" alt="screen shot 2017-09-28 at 15 01 02" src="https://user-images.githubusercontent.com/3627835/30985297-e5548294-a45d-11e7-91dc-7db173e0414c.png">
