### PR TITLE
Improve first-time contributor documentation flow

### DIFF
--- a/content/contributing/how/contents.lr
+++ b/content/contributing/how/contents.lr
@@ -34,13 +34,6 @@ particular will be tagged
 - this indicates that they are areas of particular interest where the
 project would like contributions.
 
-If you're a first time contributor, some tickets are also tagged as
-`[first-timers-only] <https://github.com/search?q=user%3Apybee+label%3Afirst-timers-only+is%3Aissue+is%3Aopen&type=>`__.
-These are special issues that have been selected because they're
-relatively simple introductions to the project, and the PyBee team
-will mentor any first time contributor in committing a patch for
-one of these issues.
-
 Platform Usage
 ---------------
 

--- a/content/contributing/how/contents.lr
+++ b/content/contributing/how/contents.lr
@@ -15,7 +15,7 @@ There are many ways to help with BeeWare.
 `First-time Contributors`_
 ---------------------------
 
-Never contributed to open source before? Let us help you! Everyone can contribute to open source, and we're here to show you how.
+If you're new to the project (or even entirely new to open source in general), the best place to start is `here </contributing/how/first-time/>`__. Everyone can contribute to open source, and we're here to show you how.
 
 .. _First-time Contributors: /contributing/how/first-time/
 
@@ -33,6 +33,13 @@ particular will be tagged
 `[up-for-grabs] <https://github.com/search?q=user%3Apybee+label%3Aup-for-grabs+is%3Aissue+is%3Aopen&type=>`__
 - this indicates that they are areas of particular interest where the
 project would like contributions.
+
+If you're a first time contributor, some tickets are also tagged as
+`[first-timers-only] <https://github.com/search?q=user%3Apybee+label%3Afirst-timers-only+is%3Aissue+is%3Aopen&type=>`__.
+These are special issues that have been selected because they're
+relatively simple introductions to the project, and the PyBee team
+will mentor any first time contributor in committing a patch for
+one of these issues.
 
 Platform Usage
 ---------------

--- a/content/contributing/how/first-time/what/contents.lr
+++ b/content/contributing/how/first-time/what/contents.lr
@@ -64,3 +64,9 @@ sort_key: 2
 ---
 summary: So you want to help - but where should you start?
 ---
+gutter:
+
+First Timers Only
+-------------------------
+
+Want to start small? Once you've poked about a bit in the tutorials, check out the BeeWare issues marked `[first-timers-only] <https://github.com/search?utf8=%E2%9C%93&q=org%3Apybee+is%3Aissue+is%3Aopen+label%3Aup-for-grabs&type=Issues&ref=searchresults>`__

--- a/content/contributing/how/first-time/what/contents.lr
+++ b/content/contributing/how/first-time/what/contents.lr
@@ -64,9 +64,3 @@ sort_key: 2
 ---
 summary: So you want to help - but where should you start?
 ---
-gutter:
-
-First Timers Only
--------------------------
-
-Want to start small? Check out the BeeWare issues marked `[first-timers-only] <https://github.com/search?utf8=%E2%9C%93&q=org%3Apybee+is%3Aissue+is%3Aopen+label%3Aup-for-grabs&type=Issues&ref=searchresults>`__


### PR DESCRIPTION
Don't send people to 'first-timers' bugs until they have gone through the tutorials. And don't tell people who have contributed to open source before (but not to this particular project) that they don't need to view the getting started page.