### PR TITLE
update various project description pages

### DIFF
--- a/content/project/projects/applications/podium/contents.lr
+++ b/content/project/projects/applications/podium/contents.lr
@@ -20,7 +20,7 @@ These presentation tools also come from a WYSIWYG (What You See Is What You Get)
 
 On top of all that, the document formats for Keynote and Powerpoint are binary blobs -- they don't lend themselves to version control, collaborative editing, and so on.
 
-The developer response to this has been to use HTML5. Recent years have seen the development of a number of HTML-based presentation tools, like `prezi <http://prezi.com/>`__, `deck.js <http://imakewebthings.com/deck.js/>`__, `keydown <https://github.com/infews/keydown>`__, and `showoff <https://github.com/drnic/showoff>`__. These tools exploit the power of HTML5 to make full screen presentations.
+The developer response to this has been to use HTML5. Recent years have seen the development of a number of HTML-based presentation tools, like `prezi <https://prezi.com/>`__, `deck.js <http://imakewebthings.com/deck.js/>`__, `keydown <https://github.com/infews/keydown>`__, and `showoff <https://github.com/drnic/showoff>`__. These tools exploit the power of HTML5 to make full screen presentations.
 
 However, by using browser technology as the basis for these tools, they miss one very important feature of WYSIWYG presentation tools: presenter mode.
 

--- a/content/project/projects/applications/podium/contents.lr
+++ b/content/project/projects/applications/podium/contents.lr
@@ -8,9 +8,30 @@ languages: py
 ---
 platforms: independent
 ---
-short_description: A slideshow presentation tool
+short_description: A markup-based slide presentation tool
 ---
-description: A slideshow presentation tool, comparable to PowerPoint or Keynote. Slides are prepared in Markdown format, and allow for speaker notes to be associated with slides.
+description: 
+
+Developers go to conferences. And when they do, they need slide decks.
+
+Unfortunately, while presentation tools like `Keynote <https://en.wikipedia.org/wiki/Keynote_(presentation_software)>`__ and `PowerPoint <https://en.wikipedia.org/wiki/Microsoft_PowerPoint>`__ are great for business presentations, they aren't well suited to the needs of developers. The mainstay of developer presentations -- code samples -- are generally painful to add to a Keynote presentation.
+
+These presentation tools also come from a WYSIWYG (What You See Is What You Get) tradition. This can be powerful, because it makes it easy to put anything you want onto a slide. But it can also be painful, because you end up spending all your time pushing pixels into the right place, instead of focussing on the content of your talk. And if you want to make a style change, you may need to apply that change manually to every slide. The lessons of separating content from markup can't be applied to a WYSIWYG world.
+
+On top of all that, the document formats for Keynote and Powerpoint are binary blobs -- they don't lend themselves to version control, collaborative editing, and so on.
+
+The developer response to this has been to use HTML5. Recent years have seen the development of a number of HTML-based presentation tools, like `prezi <http://prezi.com/>`__, `deck.js <http://imakewebthings.com/deck.js/>`__, `keydown <https://github.com/infews/keydown>`__, and `showoff <https://github.com/drnic/showoff>`__. These tools exploit the power of HTML5 to make full screen presentations.
+
+However, by using browser technology as the basis for these tools, they miss one very important feature of WYSIWYG presentation tools: presenter mode.
+
+One of the big features of Keynote and Powerpoint is that they aren't just decks of slides -- they have presenter notes and timing tools, and the display shown to the audience isn't the same as the display shown to the presenter.
+
+Many of these tools also assume that you have a good WiFi connection, and will be able to display your content live off the internet... which if you've ever been to a developer conference, you'll know is a risky proposition.
+
+Podium attempts to bridge the gap between these two poles. It is comprised of:
+
+- A simple, text-based markup format, focussed on the needs of developer presentations.
+- A graphical presentation tool that has a presenter display independent of the slide display.
 ---
 help_required: 
 ---

--- a/content/project/projects/libraries/colosseum/contents.lr
+++ b/content/project/projects/libraries/colosseum/contents.lr
@@ -12,16 +12,32 @@ short_description: A (partial) implementation of the CSS box and flexbox layout 
 ---
 description:
 
-The algorithm and test suite for this library is a language port of
+Colosseum is an independent implementation of the CSS layout algorithm based. This implementation is completely standalone - it isn’t dependent on a browser, and can be run over any box-like set of objects that need to be laid out on a page (either physical or virtual)
+
+It takes a tree of content "nodes" - such as a DOM from a HTML document - an applies CSS styling instructions to layout those nodes as boxes on the screen. In the case of `Toga </project/projects/libraries/toga/>`__, instead of laying out <div> and <span> elements, you lay out Box and Button objects. This allows you to specify incredibly complex, adaptive layouts for Toga applications.
+
+But Colosseum as a project has many other possible uses. It could be used anywhere that there is a need for describing layout outside a browser context. For example, Colosseum could be the cornerstone of a HTML to PDF renderer that doesn't require the involvement of a browser. It could also be used as a test harness and reference implementation for the CSS specification itself, providing a lightweight way to encode and test proposed changes to the specification.
+
+The current implementation was originally based on the
 `Yoga`_ project, open-sourced by Facebook.
 
+For more information about Colosseum, check out this `blog post </news/buzz/project-spotlight-colosseum/>`__ describing the project and talking about it's roadmap.
+
 .. _Yoga: https://github.com/facebook/yoga
+
+
 ---
 help_required: 
 ---
 pun:
 
-**C**-olo-**SS**-eum. 
+The Colosseum, also known as the Flavian Amphitheater, is an ancient Roman Amphitheater in the center of Rome. It is an astonding piece of ancient architecture, noted for it’s three layers of arches, framed by Doric, Ionic and Corinthian half-columns, with an attic decorate with Corinthian pilasters.
+
+Much like Doric, Ionic and Corithian columns form the fundamental architecture of the ancient Roman world, CSS is part of the fundamental architecture of modern display computing. The regular repeating structure of the Colosseum’s arches and columns mirror the regular grid-based layout of many modern web and print designs.
+
+The Colosseum was also a massive undertaking for it’s time. Undertaking to reproduce the entire CSS specification, with all it’s quirks and eccentricities, is a similarly massive undertaking.
+
+But most importantly: **C**-olo-**SS**-eum. 
 ---
 incomplete: yes
 ---

--- a/content/project/projects/libraries/colosseum/contents.lr
+++ b/content/project/projects/libraries/colosseum/contents.lr
@@ -39,7 +39,7 @@ The Colosseum was also a massive undertaking for it’s time. Undertaking to rep
 
 But most importantly: **C**-olo-**SS**-eum. 
 ---
-incomplete: yes
+incomplete: no
 ---
 rtfd_name: colosseum
 ---

--- a/content/project/projects/libraries/ouroboros/contents.lr
+++ b/content/project/projects/libraries/ouroboros/contents.lr
@@ -20,4 +20,6 @@ pun: The ouroboros is an ancient symbol depicting a serpent eating its own tail.
 ---
 image: ouroboros.png
 ---
+rtfd_name: pybee-ouroboros
+---
 github_repo: pybee/ouroboros


### PR DESCRIPTION
Update description pages for various projects.
- combines some information from the Colosseum readme on github and the blog post https://pybee.org/news/buzz/project-spotlight-colosseum/ to give a better description of the Colosseum library in a place that is more easily discovered.
- add a documentation link for ourobos
- add full description of Podium taken from github readme

Signed-off-by: Ron Fenolio <mordoc@gmail.com>