### PR TITLE
Refactor navbar to be mobile friendly

### DIFF
--- a/assets/static/beeware.css
+++ b/assets/static/beeware.css
@@ -130,7 +130,7 @@
   }
 
   .navbar-collapse {
-    background: #daa520;
+    background: #000;
     padding-top: 0.75em;
   }
 

--- a/assets/static/beeware.css
+++ b/assets/static/beeware.css
@@ -119,6 +119,34 @@
     width: 100%;
   }
 
+  .navbar {
+    padding: 0 !important;
+  }
+
+  .navbar-brand-block {
+    border-bottom: 1px solid #666;
+    padding: 0 1em 0.2em;
+    width: 100%; 
+  }
+
+  .navbar-collapse {
+    background: #daa520;
+    padding-top: 0.75em;
+  }
+
+  .navbar-collapse li {
+    border-bottom: 1px solid #666;
+    padding: 0.5em 1em 0.4em;
+  }
+
+  .navbar-toggler {
+    padding: 0.3em;
+  }
+
+  .nav-top {
+    margin: 0.7em 1em;
+  }
+
   .video {
     width: 300px;
     height: 225px;
@@ -289,6 +317,10 @@ blockquote {
 .dropdown-pull-right>.dropdown-menu {
   right: 0;
   left: auto;
+}
+
+.navbar {
+  padding-top: 1em;
 }
 
 /*----------------------------------------------------

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -69,11 +69,13 @@ ga('send', 'pageview');
   <body>
     
   <nav class="navbar navbar-expand-md navbar-dark bg-dark fixed-top">
-  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsDefault" aria-controls="navbarsDefault" aria-expanded="false" aria-label="Toggle navigation">
-    <span class="navbar-toggler-icon"></span>
-  </button>
+  <div class="nav-top">
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsDefault" aria-controls="navbarsDefault" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+  </div>
   <div class="collapse navbar-collapse" id="navbarsDefault">
-    <a class="navbar-brand" href="{{ '/'|url(alt=this.alt) }}">BeeWare</a>
+    <div class="navbar-brand-block"><a class="navbar-brand" href="{{ '/'|url(alt=this.alt) }}">BeeWare</a></div>
     <ul class="navbar-nav mr-auto">
       {{ menu_item('project') }}
       {{ menu_item('news') }}


### PR DESCRIPTION
This is a pull request related to #277 to make the navbar more friendly for mobile devices. I chose goldenrod (#daa520) to go along with the bee theme but if any of the core team members would prefer a different color i'd be game to change it.

Also I had to use !important to override the `.navbar` padding, if anyone has a recommendation of how I can do it without resorting to that it would be appreciated. I assumed the media query would override it on mobile, but that didn't work.