### PR TITLE
Fix broken links in Challenge Coins page.

### DIFF
--- a/content/contributing/challenge-coins/contents.lr
+++ b/content/contributing/challenge-coins/contents.lr
@@ -44,7 +44,7 @@ The first run of 100 BeeWare Challenge Coins were commissioned thanks to financi
 
 .. _99% Invisible: http://99percentinvisible.org/episode/coin-check/
 .. _Wikipedia: https://en.wikipedia.org/wiki/Challenge_coin
-.. _article about BeeWare: https://www.maxcdn.com/blog/beeware-be-sticky/
+.. _article about BeeWare: https://web.archive.org/web/20170923205703/https://www.maxcdn.com/blog/beeware-be-sticky/
 .. _MaxCDN: /community/members/maxcdn/
 .. _Revolution Systems: /community/members/revsys/
 .. _GitHub: /community/members/github/

--- a/content/contributing/challenge-coins/contents.lr
+++ b/content/contributing/challenge-coins/contents.lr
@@ -44,7 +44,8 @@ The first run of 100 BeeWare Challenge Coins were commissioned thanks to financi
 
 .. _99% Invisible: http://99percentinvisible.org/episode/coin-check/
 .. _Wikipedia: https://en.wikipedia.org/wiki/Challenge_coin
-.. _article about BeeWare: https://web.archive.org/web/20170923205703/https://www.maxcdn.com/blog/beeware-be-sticky/
+.. _article about BeeWare: 
+	https://web.archive.org/web/20170923205703/https://www.maxcdn.com/blog/beeware-be-sticky/
 .. _MaxCDN: /community/members/maxcdn/
 .. _Revolution Systems: /community/members/revsys/
 .. _GitHub: /community/members/github/


### PR DESCRIPTION
This PR addresses issue #330.

Screenshot of testing environment after changing the link:

![beeware - challenge coins](https://user-images.githubusercontent.com/42544553/51437693-9d060d80-1cc7-11e9-9ecf-a199e44a26e7.png)

(Notice the URL at the bottom left corner).